### PR TITLE
bump nightly versions in shipit to 72

### DIFF
--- a/api/src/shipit_api/config.py
+++ b/api/src/shipit_api/config.py
@@ -40,8 +40,8 @@ ESR_BRANCH_PREFIX = "releases/mozilla-esr"
 # day).
 # We could have used the in-tree version, but there can be race conditions,
 # e.g. version bumped, but still no builds available.
-FIREFOX_NIGHTLY = "71.0a1"
-FENNEC_NIGHTLY = "68.2a1"
+FIREFOX_NIGHTLY = "72.0a1"
+FENNEC_NIGHTLY = "68.3a1"
 # The next 6 dates are information about the current and next release
 # They must be updated at the same time as FIREFOX_NIGHTLY
 # They can be found: https://wiki.mozilla.org/Release_Management/Calendar


### PR DESCRIPTION
I made a guess with ESR. I think even though we ended up with a third version value for fennec on most recent release, ie 68.3.0, we still only want two version values here.