### PR TITLE
Automatic partials

### DIFF
--- a/api/src/shipit_api/api.py
+++ b/api/src/shipit_api/api.py
@@ -16,7 +16,7 @@ from werkzeug.exceptions import BadRequest
 from backend_common.auth import auth
 from cli_common.log import get_logger
 from cli_common.taskcluster import get_service
-from shipit_api.config import PROJECT_NAME, PULSE_ROUTE_REBUILD_PRODUCT_DETAILS, SCOPE_PREFIX, HG_PREFIX
+from shipit_api.config import HG_PREFIX, PROJECT_NAME, PULSE_ROUTE_REBUILD_PRODUCT_DETAILS, SCOPE_PREFIX
 from shipit_api.models import DisabledProduct, Phase, Release, Signoff
 from shipit_api.release import Product, get_locales, product_to_appname
 from shipit_api.tasks import ArtifactNotFound, UnsupportedFlavor, fetch_artifact, generate_action_hook, render_action_hook

--- a/api/src/shipit_api/api.py
+++ b/api/src/shipit_api/api.py
@@ -77,11 +77,7 @@ def add_release(body):
     product = body["product"]
     partial_updates = body.get("partial_updates")
     if partial_updates == "auto":
-        partial_updates = _suggest_partials(
-            product=product,
-            branch=body["branch"],
-            version=body["version"],
-        )
+        partial_updates = _suggest_partials(product=product, branch=body["branch"], version=body["version"])
     r = Release(
         product=product,
         version=body["version"],
@@ -373,8 +369,7 @@ def enable_product(product, branch):
 
 def _suggest_partials(product, branch, version, max_partials=3):
     """Return a list of suggested partials"""
-    if product not in [Product.FIREFOX.value, Product.DEVEDITION.value] \
-            or branch not in ["try", "releases/mozilla-beta"]:
+    if product not in [Product.FIREFOX.value, Product.DEVEDITION.value] or branch not in ["try", "releases/mozilla-beta"]:
         raise NotImplementedError("Partial suggestion works for automated betas only")
 
     shipped_releases = reversed(list_releases(product, branch, status=["shipped"]))
@@ -383,10 +378,6 @@ def _suggest_partials(product, branch, version, max_partials=3):
     for release in suggested_releases:
         suggested_partials[release["version"]] = {
             "buildNumber": release["build_number"],
-            "locales": get_locales(
-                f"${HG_PREFIX}/{release['branch']}",
-                release["revision"],
-                product_to_appname(product),
-            )
+            "locales": get_locales(f"${HG_PREFIX}/{release['branch']}", release["revision"], product_to_appname(product)),
         }
     return suggested_partials

--- a/api/src/shipit_api/api.yml
+++ b/api/src/shipit_api/api.yml
@@ -352,8 +352,11 @@ components:
           format: dateTime
           example: 2006-08-14T02:34:56-06:00
         partial_updates:
-          type: object
-          properties: {}
+          anyOf:
+            - type: object
+              properties: {}
+            - type: string
+              enum: [auto]
         product_key:
           type: string
           example: fennec_beta

--- a/api/src/shipit_api/api.yml
+++ b/api/src/shipit_api/api.yml
@@ -354,7 +354,21 @@ components:
         partial_updates:
           anyOf:
             - type: object
-              properties: {}
+              # Using additionalProperties allows having properties with names
+              # unknown in advance, like versions used here.
+              additionalProperties:
+                type: object
+                required:
+                  - buildNumber
+                  - locales
+                additionalProperties: false
+                properties:
+                  buildNumber:
+                    type: integer
+                  locales:
+                    type: array
+                    items:
+                      type: string
             - type: string
               enum: [auto]
         product_key:

--- a/api/src/shipit_api/models.py
+++ b/api/src/shipit_api/models.py
@@ -167,9 +167,7 @@ class Release(db.Model):
             input_common["release_enable_emefree"] = False
 
         if self.partial_updates:
-            input_common["partial_updates"] = {}
-            for partial_version, info in self.partial_updates.items():
-                input_common["partial_updates"][partial_version] = {"buildNumber": info["buildNumber"], "locales": info["locales"]}
+            input_common["partial_updates"] = self.partial_updates
         target_action = find_action("release-promotion", self.actions)
         kind = target_action["kind"]
         if kind != "hook":

--- a/api/src/shipit_api/release.py
+++ b/api/src/shipit_api/release.py
@@ -133,10 +133,8 @@ def is_eme_free_enabled(product, version):
 
 def product_to_appname(product):
     """Convert product name to appName"""
-    # Limited to the automated beta products on purpose
     if product in [Product.FIREFOX.value, Product.DEVEDITION.value]:
         return "browser"
-    raise NotImplementedError(f"Automated releases are not implemented for {product}")
 
 
 def get_locales(repo, revision, appname):

--- a/api/src/shipit_api/release.py
+++ b/api/src/shipit_api/release.py
@@ -6,6 +6,8 @@
 import enum
 import re
 
+import requests
+
 from shipit_api.config import SUPPORTED_FLAVORS
 
 # If version has two parts with no trailing specifiers like "rc", we
@@ -127,3 +129,19 @@ def is_eme_free_enabled(product, version):
         elif not is_esr(version):
             return True
     return False
+
+
+def product_to_appname(product):
+    """Convert product name to appName"""
+    # Limited to the automated beta products on purpose
+    if product in [Product.FIREFOX.value, Product.DEVEDITION.value]:
+        return "browser"
+    raise NotImplementedError(f"Automated releases are not implemented for {product}")
+
+
+def get_locales(repo, revision, appname):
+    """Fetches list of locales from mercurial"""
+    url = f"{repo}/raw-file/{revision}/{appname}/locales/l10n-changesets.json"
+    req = requests.get(url, timeout=10)
+    req.raise_for_status()
+    return list(req.json().keys())

--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -31,14 +31,6 @@ module.exports = {
           numberOfPartials: 4,
         },
         {
-          prettyName: 'ESR60',
-          project: 'mozilla-esr60',
-          branch: 'releases/mozilla-esr60',
-          repo: 'https://hg.mozilla.org/releases/mozilla-esr60',
-          enableReleaseEta: true,
-          numberOfPartials: 5,
-        },
-        {
           prettyName: 'ESR68',
           project: 'mozilla-esr68',
           branch: 'releases/mozilla-esr68',
@@ -102,13 +94,6 @@ module.exports = {
           project: 'comm-beta',
           branch: 'releases/comm-beta',
           repo: 'https://hg.mozilla.org/releases/comm-beta',
-          enableReleaseEta: false,
-        },
-        {
-          prettyName: 'ESR60',
-          project: 'comm-esr60',
-          branch: 'releases/comm-esr60',
-          repo: 'https://hg.mozilla.org/releases/comm-esr60',
           enableReleaseEta: false,
         },
         {

--- a/frontend/src/views/NewRelease/index.js
+++ b/frontend/src/views/NewRelease/index.js
@@ -251,7 +251,7 @@ export default class NewRelease extends React.Component {
           this.state.selectedProduct.appName,
         );
         return [
-          version, { buildNumber, locales },
+          version, { buildNumber: parseInt(buildNumber, 10), locales },
         ];
       }));
       const partialUpdatesFlattened = {};


### PR DESCRIPTION
* Partials can be automatically assigned if "auto" is passed
* Automatic partials enabled for automatic betas only. Enabling them for
other branches requires handling more edgecases, like multiple branches
for RCs and early ESR releases
* Remove ESR60