### PR TITLE
Use APP_CHANNEL in scopes

### DIFF
--- a/api/src/shipit_api/config.py
+++ b/api/src/shipit_api/config.py
@@ -3,12 +3,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import os
 import pathlib
 import tempfile
 
 PROJECT_NAME = "shipit/api"
 APP_NAME = "shipit_api"
-SCOPE_PREFIX = f"project:releng:services/{APP_NAME}"
+APP_CHANNEL = os.environ.get("APP_CHANNEL", "development")
+SCOPE_PREFIX = f"project:releng:services/{APP_NAME}/{APP_CHANNEL}"
 
 # A route key that triggers rebuild of product details.
 # Worker will listen to this route key to trigger the rebuild.


### PR DESCRIPTION
This adds the deployment environment name aka APP_CHANNEL to the required scopes. The Auth0 based logins don't require any changes, the permissions will be automatically populated at boot time. The TC clients' scopes should be updates by adding the new scopes before we land this PR. This will also solve the issue that the staging tc clients can poke some prod API endpoints.