### PR TITLE
Bump nightly version as part of mergeduty

### DIFF
--- a/api/src/shipit_api/config.py
+++ b/api/src/shipit_api/config.py
@@ -40,8 +40,8 @@ ESR_BRANCH_PREFIX = "releases/mozilla-esr"
 # day).
 # We could have used the in-tree version, but there can be race conditions,
 # e.g. version bumped, but still no builds available.
-FIREFOX_NIGHTLY = "72.0a1"
-FENNEC_NIGHTLY = "68.3a1"
+FIREFOX_NIGHTLY = "73.0a1"
+FENNEC_NIGHTLY = "68.4a1"
 # The next 6 dates are information about the current and next release
 # They must be updated at the same time as FIREFOX_NIGHTLY
 # They can be found: https://wiki.mozilla.org/Release_Management/Calendar


### PR DESCRIPTION
Not to be merged until we have valid nightlies for both products, later on tonight.