### PR TITLE
Do use `docker login`

### DIFF
--- a/api/docker.d/push_image.sh
+++ b/api/docker.d/push_image.sh
@@ -19,9 +19,10 @@ echo "=== Re-tagging docker image ==="
 export DOCKER_ARCHIVE_TAG="${DOCKER_TAG}-$(cat ./version.txt)-$(date +%Y%m%d%H%M%S)-${GIT_HEAD_REV}"
 docker tag $DOCKER_REPO:$DOCKER_TAG $DOCKER_REPO:$DOCKER_ARCHIVE_TAG
 
-echo "=== Logging to docker hub ==="
-dockerhub_password=$(wget -qO- $SECRET_URL | jq '.["secret"]["docker"]["password"]')
-docker login --email=$DOCKERHUB_EMAIL --username=$DOCKERHUB_USER --password=$dockerhub_password
+echo "=== Generating dockercfg ==="
+# docker login stopped working in Taskcluster for some reason
+wget -qO- $SECRET_URL | jq '.secret.docker.dockercfg' > /root/.dockercfg
+chmod 600 /root/.dockercfg
 
 echo "=== Pushing to docker hub ==="
 docker push $DOCKER_REPO:$DOCKER_TAG


### PR DESCRIPTION
For some reason `docker login` stopped working with Taskcluster's
`dind`. Generating `.dockercfg` fixes the issue.