### PR TITLE
Do not map over `null`

### DIFF
--- a/frontend/src/views/NewXPIRelease/index.js
+++ b/frontend/src/views/NewXPIRelease/index.js
@@ -307,7 +307,7 @@ export default class NewXPIelease extends React.Component {
                   id="input-dropdown-addon"
                   title="XPIs"
                 >
-                  {this.state.xpis.map(xpi => (
+                  {this.state.xpis && this.state.xpis.map(xpi => (
                     <MenuItem
                       onClick={() => this.handleXPIPick(
                         xpi.manifest_revision,


### PR DESCRIPTION
This will prevent the edge case, where the github token doesn't have
enough permissions to draw a blank page.