### PR TITLE
Do not implicitly ship releases

### DIFF
--- a/api/src/shipit_api/api.py
+++ b/api/src/shipit_api/api.py
@@ -171,9 +171,6 @@ def do_schedule_phase(session, phase):
             ph.completed_by = current_user.get_id()
             ph.completed = completed
 
-    if all([ph.submitted for ph in phase.release.phases]):
-        phase.release.status = "shipped"
-        phase.release.completed = completed
     session.commit()
     return phase
 


### PR DESCRIPTION
This is a leftover from the hybrid model where we had shipit v2 for
everything except product-details, and shipitscript would talk to shipit
v1 to update the status without touching shipit v2. After switching to
v2 only, we didn't update this block. We didn't notice it because the
production details rebuild step is explicitly triggered by shipitscript,
so we never shipped releases to the public without an [explicit
shipitscript "signoff"](https://github.com/mozilla-releng/scriptworker-scripts/blob/3477570661f416af57533e9b3fa7d5b840828b96/shipitscript/src/shipitscript/ship_actions.py#L103).

Fixes #119