### PR TITLE
Fix branch key uniqueness

### DIFF
--- a/frontend/src/views/NewRelease/index.js
+++ b/frontend/src/views/NewRelease/index.js
@@ -438,7 +438,7 @@ export default class NewRelease extends React.Component {
               {this.state.selectedProduct.branches &&
                this.state.selectedProduct.branches.map(branch => (
                  <Button
-                   key={branch.project}
+                   key={`${this.state.selectedProduct.product}-${branch.prettyName}`}
                    bsStyle={this.state.selectedBranch === branch ? 'primary' : 'default'}
                    bsSize="large"
                    onClick={() => this.handleBranch(branch)}


### PR DESCRIPTION
Because `branch.project` is not unique, we may end up with [this mess](https://img.lgtm.ca/56f05977.png) after a few clicks.