### PR TITLE
Use pessimistic reconnect

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -52,6 +52,11 @@ if "PULSE_USER" in os.environ:
 # -- DATABASE -----------------------------------------------------------------
 
 SQLALCHEMY_TRACK_MODIFICATIONS = False
+# Use pessimistic disconnect handling as described at
+# https://docs.sqlalchemy.org/en/13/core/pooling.html#disconnect-handling-pessimistic
+# In some edge cases, when GCP performs maintenance on the database, the
+# connection goes away, but sqlalchemy doesn't detect it.
+SQLALCHEMY_ENGINE_OPTIONS = {"pool_pre_ping": True}
 SQLALCHEMY_DATABASE_URI = secrets["DATABASE_URL"]
 
 # -- AUTH --------------------------------------------------------------------

--- a/api/settings_public.py
+++ b/api/settings_public.py
@@ -8,4 +8,9 @@ import os
 SQLALCHEMY_DATABASE_URI = os.environ["DATABASE_URL"]
 APP_CHANNEL = os.environ["APP_CHANNEL"]
 SQLALCHEMY_TRACK_MODIFICATIONS = False
+# Use pessimistic disconnect handling as described at
+# https://docs.sqlalchemy.org/en/13/core/pooling.html#disconnect-handling-pessimistic
+# In some edge cases, when GCP performs maintenance on the database, the
+# connection goes away, but sqlalchemy doesn't detect it.
+SQLALCHEMY_ENGINE_OPTIONS = {"pool_pre_ping": True}
 READONLY_API = True


### PR DESCRIPTION
Today the dev database went through a GCP maintenance process and the
app started returning 500 errors with `(psycopg2.OperationalError) SSL
connection has been closed unexpectedly.`

Using the pessimistic disconnect should be fine for a low traffic app
like shipit.