### PR TITLE
Import models before db.create_all()

### DIFF
--- a/api/src/shipit_api/admin/__init__.py
+++ b/api/src/shipit_api/admin/__init__.py
@@ -6,6 +6,8 @@
 import os
 
 import backend_common
+import shipit_api.admin.models  # noqa
+import shipit_api.common.models  # noqa
 from cli_common.taskcluster import get_service
 from shipit_api.admin.worker import cmd
 from shipit_api.common.config import APP_NAME


### PR DESCRIPTION
db.create_all() requires the models imported before the call. It worked
fine before we split public and admin APIs, but now the imports are a
bit more indirect, so better to do this explicitly.
