### PR TITLE
Bug 1620112 - Unify XPI and Gecko status API

### DIFF
--- a/api/src/shipit_api/admin/api.yml
+++ b/api/src/shipit_api/admin/api.yml
@@ -524,30 +524,7 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/XPIRelease'
-    patch:
-      summary: Update release status
-      operationId: shipit_api.admin.xpi.update_release_status
-      parameters:
-      - name: name
-        in: path
-        description: release name
-        required: true
-        schema:
-          type: string
-      requestBody:
-        description: Release status object
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ReleaseStatus'
-        required: true
-      responses:
-        200:
-          description: Release updated
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/XPIRelease'
+
   /xpi/releases/{name}/{phase}:
     get:
       summary: Phase info

--- a/api/src/shipit_api/admin/models.py
+++ b/api/src/shipit_api/admin/models.py
@@ -68,6 +68,8 @@ class XPIRelease(db.Model, ReleaseBase):
     completed = sa.Column(sa.DateTime)
 
     phase_class = XPIPhase
+    product = "xpi"  # Used in notifications
+    product_details_enabled = False
 
     def __init__(self, revision, xpi, build_number, status, xpi_type, project, repo_url=""):
         self.name = f"{xpi.name}-{xpi.version}-build{build_number}"
@@ -80,7 +82,6 @@ class XPIRelease(db.Model, ReleaseBase):
         self.xpi_type = xpi_type
         self.project = project
         self.repo_url = repo_url
-        self.product = xpi.name
 
     def phase_signoffs(self, phase):
         return [

--- a/api/src/shipit_api/admin/xpi.py
+++ b/api/src/shipit_api/admin/xpi.py
@@ -8,7 +8,6 @@ from sqlalchemy.exc import IntegrityError
 from taskcluster.exceptions import TaskclusterRestFailure
 from werkzeug.exceptions import BadRequest
 
-from backend_common.auth import auth
 from cli_common.taskcluster import get_root_url
 from shipit_api.admin.api import do_schedule_phase
 from shipit_api.admin.github import get_xpi_type
@@ -156,18 +155,3 @@ def phase_signoff(name, phase, body):
     release = phase_obj.release
     logger.info("Phase %s of %s signed off by %s", phase, release.name, who)
     return dict(signoffs=signoffs)
-
-
-@auth.require_permissions([SCOPE_PREFIX + "/update_release_status"])
-def update_release_status(name, body):
-    session = current_app.db.session
-    release = session.query(XPIRelease).filter(XPIRelease.name == name).first_or_404()
-
-    status = body["status"]
-    release.status = status
-    if status == "shipped":
-        release.completed = datetime.datetime.utcnow()
-
-    session.commit()
-    logger.info("Status of %s changed to %s", release.name, status)
-    return release.json

--- a/api/src/shipit_api/common/models.py
+++ b/api/src/shipit_api/common/models.py
@@ -97,6 +97,8 @@ class Phase(db.Model, PhaseBase):
 
 
 class ReleaseBase:
+    product_details_enabled = True
+
     @property
     def allow_phase_skipping(self):
         # Phases can be skipped for betas and try only. The API doesn't enforce this.


### PR DESCRIPTION
Addresses https://github.com/mozilla-releng/scriptworker-scripts/pull/163

I tested this in dev and it worked fine for a Firefox release.

After this landed, we can remove the corresponding product detail API call from shipitscript.