### PR TITLE
Bug 1618454 - stop using Taskcluster secrets as app configs

### DIFF
--- a/api/src/backend_common/taskcluster.py
+++ b/api/src/backend_common/taskcluster.py
@@ -33,16 +33,3 @@ def get_service(service_name):
     """
     options = get_options(service_name)
     return getattr(taskcluster, service_name.capitalize())(options)
-
-
-def get_secrets(name, project_name, root_url, client_id, access_token):
-    """
-    Fetch a specific set of secrets
-
-    """
-    # this will be removed after we switch to SOPS secrets
-    # Duplicating the code above to avoid flask context issues
-
-    tc_options = {"rootUrl": root_url, "maxRetries": 12, "credentials": {"clientId": client_id, "accessToken": access_token}}
-    secrets_service = taskcluster.Secrets(tc_options)
-    return secrets_service.get(name).get("secret", {}).get(project_name, {})

--- a/api/src/shipit_api/admin/settings.py
+++ b/api/src/shipit_api/admin/settings.py
@@ -5,36 +5,19 @@
 
 import base64
 
-from decouple import Config
-from decouple import config as dc_config
+from decouple import config
 
 from backend_common.auth import create_auth0_secrets_file
-from backend_common.taskcluster import get_secrets
-from shipit_api.common.config import PROJECT_NAME, SCOPE_PREFIX, SUPPORTED_FLAVORS
+from shipit_api.common.config import SCOPE_PREFIX, SUPPORTED_FLAVORS
 
 # TODO: 1) rename "development" to "local" 2) remove "staging" when fully migrated
 supported_channels = ["dev", "development", "staging", "production"]
-APP_CHANNEL = dc_config("APP_CHANNEL", default=None)
-TASKCLUSTER_ROOT_URL = dc_config("TASKCLUSTER_ROOT_URL")
-TASKCLUSTER_CLIENT_ID = dc_config("TASKCLUSTER_CLIENT_ID")
-TASKCLUSTER_ACCESS_TOKEN = dc_config("TASKCLUSTER_ACCESS_TOKEN")
-
-if APP_CHANNEL:
-    config = dc_config
-else:
-    # APP_CHANNEL is not defined as environment variable in GCP
-    # TODO: This section will be removed after we switch to SOPS secrets
-    # Until bug 1618454 is fixed, fall back to the Taskcluster secrets if the
-    # corresponding environment variable is not defined
-    TASKCLUSTER_SECRET = dc_config("TASKCLUSTER_SECRET")
-    secrets = get_secrets(TASKCLUSTER_SECRET, PROJECT_NAME, TASKCLUSTER_ROOT_URL, TASKCLUSTER_CLIENT_ID, TASKCLUSTER_ACCESS_TOKEN)
-    config = Config(repository=secrets)
-    APP_CHANNEL = config("APP_CHANNEL")
-
-if APP_CHANNEL not in supported_channels:
-    raise ValueError(f"APP_CHANNEL should be one of {supported_channels}, `{APP_CHANNEL}` given")
 
 # required
+APP_CHANNEL = config("APP_CHANNEL")
+TASKCLUSTER_ROOT_URL = config("TASKCLUSTER_ROOT_URL")
+TASKCLUSTER_CLIENT_ID = config("TASKCLUSTER_CLIENT_ID")
+TASKCLUSTER_ACCESS_TOKEN = config("TASKCLUSTER_ACCESS_TOKEN")
 AUTH_DOMAIN = config("AUTH_DOMAIN")
 AUTH_CLIENT_ID = config("AUTH_CLIENT_ID")
 AUTH_CLIENT_SECRET = config("AUTH_CLIENT_SECRET")
@@ -58,6 +41,9 @@ CORS_ORIGINS = config("CORS_ORIGINS", default=None)
 IRC_NOTIFICATIONS_OWNERS_PER_PRODUCT = config("IRC_NOTIFICATIONS_OWNERS_PER_PRODUCT", default=None)
 IRC_NOTIFICATIONS_CHANNELS_PER_PRODUCT = config("IRC_NOTIFICATIONS_CHANNELS_PER_PRODUCT", default=None)
 PRODUCT_DETAILS_GIT_REPO_URL = config("PRODUCT_DETAILS_GIT_REPO_URL", default=None)
+
+if APP_CHANNEL not in supported_channels:
+    raise ValueError(f"APP_CHANNEL should be one of {supported_channels}, `{APP_CHANNEL}` given")
 
 # -- DATABASE -----------------------------------------------------------------
 

--- a/api/src/shipit_api/admin/worker.py
+++ b/api/src/shipit_api/admin/worker.py
@@ -4,74 +4,47 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import asyncio
-import json
 import logging
 
 import click
 import flask
-from decouple import Config
 
-import cli_common.pulse
-import shipit_api.common.config
-from backend_common.taskcluster import get_secrets
+from cli_common.pulse import create_consumer, run_consumer
 from shipit_api.admin.product_details import rebuild
+from shipit_api.common.config import BREAKPOINT_VERSION, PROJECT_NAME, PULSE_ROUTE_REBUILD_PRODUCT_DETAILS
 
 logger = logging.getLogger(__name__)
 
 
-def rebuild_product_details(default_git_repo_url, default_folder_in_repo, default_channel, default_breakpoint_version, default_clean_working_copy):
-    """Rebuild product details.
-    """
+def rebuild_product_details(git_repo_url, folder_in_repo, app_channel, breakpoint_version):
+    """Rebuild product details."""
     logger.debug("Rebuilding product details")
-    root_url = flask.current_app.config["TASKCLUSTER_ROOT_URL"]
-    client_id = flask.current_app.config["TASKCLUSTER_CLIENT_ID"]
-    access_token = flask.current_app.config["TASKCLUSTER_ACCESS_TOKEN"]
-    secret = flask.current_app.config["TASKCLUSTER_SECRET"]
-    logger.debug(f"Fetching secrets from {secret}")
-    secrets = Config(repository=get_secrets(secret, shipit_api.common.config.PROJECT_NAME, root_url, client_id, access_token))
-
-    git_repo_url = secrets("PRODUCT_DETAILS_GIT_REPO_URL", default=default_git_repo_url)
-    default_channel = default_channel or secrets("APP_CHANNEL", default="master")
-    default_breakpoint_version = secrets("BREAKPOINT_VERSION", default=default_breakpoint_version)
 
     async def rebuild_product_details_async(channel, body, envelope, properties):
         await channel.basic_client_ack(delivery_tag=envelope.delivery_tag)
         logger.info("Marked pulse message as acknowledged.")
-
-        body = json.loads(body.decode("utf-8"))
-
-        logger.debug("Get rebuild parameters from request payload: %s", body)
-        breakpoint_version = body.get("breakpoint_version", default_breakpoint_version)
-        clean_working_copy = body.get("clean_working_copy", default_clean_working_copy)
-        channel_ = body.get("channel", default_channel)
-        folder_in_repo = body.get("folder_in_repo", default_folder_in_repo)
-
-        if None in (channel_, git_repo_url, folder_in_repo):
-            raise click.ClickException("One of the rebuild product details parameters is not set correctly.")
-
-        await rebuild(flask.current_app.db.session, channel_, git_repo_url, folder_in_repo, breakpoint_version, clean_working_copy)
+        await rebuild(flask.current_app.db.session, app_channel, git_repo_url, folder_in_repo, breakpoint_version)
         logger.info("Product details rebuilt")
 
     return rebuild_product_details_async
 
 
 @click.command()
-@click.option("--git-repo-url", type=str, required=False, default=None)
-@click.option("--folder-in-repo", type=str, required=True, default="public/")
-@click.option("--channel", type=click.Choice(["master", "testing", "staging", "production"]), default=None)
-@click.option("--breakpoint-version", default=shipit_api.common.config.BREAKPOINT_VERSION, type=int)
-@click.option("--clean-working-copy", is_flag=True, default=True)
 @flask.cli.with_appcontext
-def cmd(git_repo_url, folder_in_repo, channel, breakpoint_version, clean_working_copy):
-    pulse_user = flask.current_app.config["PULSE_USER"]
-    pulse_pass = flask.current_app.config["PULSE_PASSWORD"]
-    exchange = f"exchange/{pulse_user}/{shipit_api.common.config.PROJECT_NAME}"
-    rebuild_product_details_consumer = cli_common.pulse.create_consumer(
+def cmd():
+    app_config = flask.current_app.config
+    app_channel = app_config["APP_CHANNEL"]
+    git_repo_url = app_config["PRODUCT_DETAILS_GIT_REPO_URL"]
+    pulse_user = app_config["PULSE_USER"]
+    pulse_pass = app_config["PULSE_PASSWORD"]
+    exchange = f"exchange/{pulse_user}/{PROJECT_NAME}"
+    folder_in_repo = "public/"
+    rebuild_product_details_consumer = create_consumer(
         pulse_user,
         pulse_pass,
         exchange,
-        shipit_api.common.config.PULSE_ROUTE_REBUILD_PRODUCT_DETAILS,
-        rebuild_product_details(git_repo_url, folder_in_repo, channel, breakpoint_version, clean_working_copy),
+        PULSE_ROUTE_REBUILD_PRODUCT_DETAILS,
+        rebuild_product_details(git_repo_url, folder_in_repo, app_channel, BREAKPOINT_VERSION),
     )
-    logger.info("Listening for new messages on %s %s", exchange, shipit_api.common.config.PULSE_ROUTE_REBUILD_PRODUCT_DETAILS)
-    cli_common.pulse.run_consumer(asyncio.gather(*[rebuild_product_details_consumer]))
+    logger.info("Listening for new messages on %s %s", exchange, PULSE_ROUTE_REBUILD_PRODUCT_DETAILS)
+    run_consumer(asyncio.gather(*[rebuild_product_details_consumer]))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       - SECRET_KEY_BASE64=bm90YXNlY3JldA== # notasecret
       - TASKCLUSTER_CLIENT_ID
       - TASKCLUSTER_ACCESS_TOKEN
-      - TASKCLUSTER_SECRET
       - TASKCLUSTER_ROOT_URL=https://firefox-ci-tc.services.mozilla.com
       - GITHUB_TOKEN
       - GITHUB_SKIP_PRIVATE_REPOS=1


### PR DESCRIPTION
We are ready to get rid of Taskcluster secrets \o/

I also changed `worker.py`, so it uses `settings.py` instead of environment variables and drops the command line parameters and amqp body - we never used those, they just make the code harder to read.

I tested this in dev and up to the worker and everything looks fine.