### PR TITLE
Bug 1614287 - Remove Fennec Beta from shipit now that the Fenix migra…

### DIFF
--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -462,7 +462,6 @@ SUPPORTED_FLAVORS = {
         {"name": "push_thunderbird", "in_previous_graph_ids": True},
         {"name": "ship_thunderbird", "in_previous_graph_ids": True},
     ],
-    "fennec_beta": [{"name": "promote_fennec_beta", "in_previous_graph_ids": True}, {"name": "ship_fennec_beta", "in_previous_graph_ids": True}],
     "fennec_release": [{"name": "promote_fennec_release", "in_previous_graph_ids": True}, {"name": "ship_fennec_release", "in_previous_graph_ids": True}],
     "fennec_release_rc": [
         {"name": "promote_fennec_release", "in_previous_graph_ids": True},

--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -55,16 +55,6 @@ module.exports = {
           disableable: false,
         },
         {
-          prettyName: 'Try Beta',
-          project: 'maple',
-          branch: 'try',
-          repo: 'https://hg.mozilla.org/try',
-          enableReleaseEta: false,
-          productKey: 'fennec_beta',
-          versionFile: 'mobile/android/config/version-files/beta/version_display.txt',
-          disableable: true,
-        },
-        {
           prettyName: 'Try Release',
           project: 'maple',
           branch: 'try',

--- a/frontend/src/configs/development.js
+++ b/frontend/src/configs/development.js
@@ -46,16 +46,6 @@ module.exports = {
           disableable: false,
         },
         {
-          prettyName: 'Try Beta',
-          project: 'maple',
-          branch: 'try',
-          repo: 'https://hg.mozilla.org/try',
-          enableReleaseEta: false,
-          disableable: true,
-          productKey: 'fennec_beta',
-          versionFile: 'mobile/android/config/version-files/beta/version_display.txt',
-        },
-        {
           prettyName: 'Try Release',
           project: 'maple',
           branch: 'try',

--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -53,16 +53,6 @@ module.exports = {
       appName: 'browser',
       branches: [
         {
-          prettyName: 'Beta',
-          project: 'mozilla-esr68',
-          branch: 'releases/mozilla-esr68',
-          repo: 'https://hg.mozilla.org/releases/mozilla-esr68',
-          enableReleaseEta: false,
-          productKey: 'fennec_beta',
-          versionFile: 'mobile/android/config/version-files/beta/version_display.txt',
-          disableable: true,
-        },
-        {
           prettyName: 'Release',
           project: 'mozilla-esr68',
           branch: 'releases/mozilla-esr68',


### PR DESCRIPTION
…tion is started

This patch is about re-landing https://github.com/mozilla-releng/shipit/pull/156 which was prematurely deployed. We needed to ship many more Fennec Beta because of a schedule shift.

#156 was reverted in https://github.com/mozilla-releng/shipit/pull/173