### PR TITLE
Switch more things to use the pubic API

### DIFF
--- a/frontend/src/components/api.js
+++ b/frontend/src/components/api.js
@@ -1,4 +1,4 @@
-import { SHIPIT_API_URL } from '../config';
+import { SHIPIT_API_URL, SHIPIT_PUBLIC_API_URL } from '../config';
 
 /**
  * Get build numbers from the API endpoint.
@@ -7,7 +7,7 @@ import { SHIPIT_API_URL } from '../config';
  * started yet.
  */
 export async function getBuildNumbers(product, branch, version) {
-  const url = new URL(`${SHIPIT_API_URL}/releases`);
+  const url = new URL(`${SHIPIT_PUBLIC_API_URL}/releases`);
   const params = new URLSearchParams({
     product,
     branch,
@@ -27,7 +27,7 @@ export async function getBuildNumbers(product, branch, version) {
  * combination. Optionally the version can be specified.
  */
 export async function getShippedReleases(product, branch, version = null, buildNumber = null) {
-  const url = new URL(`${SHIPIT_API_URL}/releases`);
+  const url = new URL(`${SHIPIT_PUBLIC_API_URL}/releases`);
   const params = new URLSearchParams({
     product,
     branch,

--- a/frontend/src/views/ListReleases/index.js
+++ b/frontend/src/views/ListReleases/index.js
@@ -4,7 +4,7 @@ import { object } from 'prop-types';
 import ReactInterval from 'react-interval';
 import { Queue } from 'taskcluster-client-web';
 import libUrls from 'taskcluster-lib-urls';
-import config, { SHIPIT_API_URL, TASKCLUSTER_ROOT_URL } from '../../config';
+import config, { SHIPIT_API_URL, SHIPIT_PUBLIC_API_URL, TASKCLUSTER_ROOT_URL } from '../../config';
 import { getApiHeaders, getShippedReleases } from '../../components/api';
 
 const statusStyles = {
@@ -46,7 +46,7 @@ export default class ListReleases extends React.Component {
 
   getReleases = async () => {
     try {
-      const req = await fetch(`${SHIPIT_API_URL}/releases`);
+      const req = await fetch(`${SHIPIT_PUBLIC_API_URL}/releases`);
       const releases = await req.json();
       let message = '';
       if (releases.length === 0) {


### PR DESCRIPTION
I needed to move some the signoff stuff to be loaded later, to deal with the fact that it isn't available in the public API. I'm not sure if it not being public is deliberate, or if it could be switched to public.

Also, getting this data currently fails with an exception, which causes the modal to not open. While this might be reasonable behavior, it would probably better to be explicit about it, rather than the accidental behavior it currently has.