### PR TITLE
adjust signoffs per discussions

### DIFF
--- a/api/src/shipit_api/admin/settings.py
+++ b/api/src/shipit_api/admin/settings.py
@@ -71,22 +71,9 @@ ADMIN_GROUP = [
     "sfraser@mozilla.com",
     "tprince@mozilla.com",
 ]
-XPI_PRIVILEGED_ADMIN_GROUP = [
-    "rdalal@mozilla.com",
-    "mcooper@mozilla.com",
-    "awagner@mozilla.com",
-    "mbanner@mozilla.com",
-    "dharvey@mozilla.com"
-]
-XPI_SYSTEM_ADMIN_GROUP = [
-    "rdalal@mozilla.com",
-    "mcooper@mozilla.com"
-]
-XPI_MOZILLAONLINE_PRIVILEGED_GROUP = [
-    "bzhao@mozilla.com",
-    "jxia@mozilla.com",
-    "yliu@mozilla.com"
-]
+XPI_PRIVILEGED_ADMIN_GROUP = ["rdalal@mozilla.com", "mcooper@mozilla.com", "awagner@mozilla.com", "mbanner@mozilla.com", "dharvey@mozilla.com"]
+XPI_SYSTEM_ADMIN_GROUP = ["rdalal@mozilla.com", "mcooper@mozilla.com"]
+XPI_MOZILLAONLINE_PRIVILEGED_GROUP = ["bzhao@mozilla.com", "jxia@mozilla.com", "yliu@mozilla.com"]
 GROUPS = {
     "admin": ADMIN_GROUP,
     "firefox-signoff": ["jcristau@mozilla.com", "pchevrel@mozilla.com", "rvandermeulen@mozilla.com"],

--- a/api/src/shipit_api/admin/settings.py
+++ b/api/src/shipit_api/admin/settings.py
@@ -71,15 +71,33 @@ ADMIN_GROUP = [
     "sfraser@mozilla.com",
     "tprince@mozilla.com",
 ]
+XPI_PRIVILEGED_ADMIN_GROUP = [
+    "rdalal@mozilla.com",
+    "mcooper@mozilla.com",
+    "awagner@mozilla.com",
+    "mbanner@mozilla.com",
+    "dharvey@mozilla.com"
+]
+XPI_SYSTEM_ADMIN_GROUP = [
+    "rdalal@mozilla.com",
+    "mcooper@mozilla.com"
+]
+XPI_MOZILLAONLINE_PRIVILEGED_GROUP = [
+    "bzhao@mozilla.com",
+    "jxia@mozilla.com",
+    "yliu@mozilla.com"
+]
 GROUPS = {
     "admin": ADMIN_GROUP,
     "firefox-signoff": ["jcristau@mozilla.com", "pchevrel@mozilla.com", "rvandermeulen@mozilla.com"],
     "fenix-signoff": ["jcristau@mozilla.com", "pchevrel@mozilla.com", "rvandermeulen@mozilla.com"],
     "thunderbird-signoff": ["vseerror@lehigh.edu", "mozilla@jorgk.com", "thunderbird@calypsoblue.org"],
-    # We use 3 separate groups for privileged, mozillaonline-privileged, and system addon type
-    "xpi_privileged_signoff": ["rdalal@mozilla.com", "mcooper@mozilla.com", "awagner@mozilla.com", "mbanner@mozilla.com", "dharvey@mozilla.com"],
-    "xpi_system_signoff": ["rdalal@mozilla.com", "mcooper@mozilla.com"],
-    "xpi_mozillaonline-privileged_signoff": ["bzhao@mozilla.com", "jxia@mozilla.com", "yliu@mozilla.com"] + ADMIN_GROUP,
+    # XPI signoffs. These are in flux.
+    # Adding Releng as a backup to all of these, for bus factor. Releng should
+    # only sign off if requested by someone in the appropriate group.
+    "xpi_privileged_signoff": XPI_PRIVILEGED_ADMIN_GROUP + ADMIN_GROUP,
+    "xpi_system_signoff": XPI_SYSTEM_ADMIN_GROUP + ADMIN_GROUP,
+    "xpi_mozillaonline-privileged_signoff": XPI_MOZILLAONLINE_PRIVILEGED_GROUP + ADMIN_GROUP,
 }
 
 AUTH0_AUTH_SCOPES = dict()

--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -494,22 +494,26 @@ SIGNOFFS = {
     #     },
     # },
     "xpi": {
+        # XXX split `privileged` into `privileged-internal` and `privileged-studies`.
+        #     The latter will have stricter QA signoff requirements.
         "privileged": {
             "promote": [
-                {"name": "Releng", "description": "Promote XPI", "permissions": "admin"},
-                {"name": "XPI admin", "description": "Promote XPI", "permissions": "xpi_privileged_signoff"},
+                {"name": "Privileged webextension admin", "description": "Promote XPI", "permissions": "xpi_privileged_signoff"},
+                {"name": "Privileged webextension admin", "description": "Promote XPI", "permissions": "xpi_privileged_signoff"},
             ],
         },
+        # XXX replace the 2nd `system` signoff with `xpi_system_qa_signoff` once
+        #     that team is defined and granted access to shipit
         "system": {
             "promote": [
-                {"name": "Releng", "description": "Promote XPI", "permissions": "admin"},
-                {"name": "XPI admin", "description": "Promote XPI", "permissions": "xpi_system_signoff"},
+                {"name": "System addon admin", "description": "Promote XPI", "permissions": "xpi_system_signoff"},
+                {"name": "System addon admin", "description": "Promote XPI", "permissions": "xpi_system_signoff"},
             ],
         },
         "mozillaonline-privileged": {
             "promote": [
-                {"name": "MozillaOnline XPI admin", "description": "Promote XPI", "permissions": "xpi_mozillaonline-privileged_signoff"},
-                {"name": "MozillaOnline XPI admin 2", "description": "Promote XPI", "permissions": "xpi_mozillaonline-privileged_signoff"},
+                {"name": "MozillaOnline privileged webextension admin", "description": "Promote XPI", "permissions": "xpi_mozillaonline-privileged_signoff"},
+                {"name": "Privileged webextension admin", "description": "Promote XPI", "permissions": "xpi_privileged_signoff"},
             ],
         },
     },


### PR DESCRIPTION
This will adjust signoffs as follows:

- privileged webextensions will require 2 people from either the privileged admin group or releng to sign off.
- system addons will require 2 people from either the system admin group or releng to sign off.
- mozillaonline will require 1 person from the mozillaonline group or releng, plus 1 person from the privileged admin group or releng, to sign off.

In each case, releng is a backup for bus factor, and should defer to someone from the appropriate team first.

In the coming days/weeks, we should:
- potentially split `internal` privileged addons from `studies` privileged addons, to allow for stricter signoffs on the latter;
- potentially add `qa` signoff groups for `system` and/or `studies` addons;
- make sure MozillaOnline understands the ramifications of these changes;
- document this, including how and when to sign off;
- adjust the [email notifications](https://github.com/mozilla-extensions/xpi-manifest/issues/17) so the appropriate people are notified when these releases happen.