### PR TITLE
Do not try to parse vesrsion

### DIFF
--- a/frontend/src/components/vcs.js
+++ b/frontend/src/components/vcs.js
@@ -102,7 +102,12 @@ export async function getVersion(repo, revision, appName, versionFile) {
     authRequired = true;
   }
 
-  const res = await axios.get(url, { authRequired });
+  // default transformResponse tries to parse the response. Sometimes version
+  // strings become integers, "78.0" becomes 78. Return the value as is instead.
+  const res = await axios.get(url, {
+    authRequired,
+    transformResponse: [data => data],
+  });
 
   if (res.status === 200) {
     const version = res.data;


### PR DESCRIPTION
axios tries to parse the reponse by default, what causes version numbers
become numbers in some cases. For example, "78.0" becomes 78.

https://github.com/axios/axios/blob/5b08fc4ac7ecc896efa37952645ea578a3609fc2/lib/defaults.js#L61