### PR TITLE
Use last git commit for XPI manifest

### DIFF
--- a/frontend/src/components/vcs.js
+++ b/frontend/src/components/vcs.js
@@ -29,6 +29,12 @@ export async function getGithubCommits(repoOwner, repoName, branch) {
   return req.data;
 }
 
+export async function getLatestGithubCommit(repoOwner, repoName, branch) {
+  const commits = await getGithubCommits(repoOwner, repoName, branch);
+
+  return commits[0];
+}
+
 export async function getXpis(owner, repo, commit) {
   const url = `/github/xpis/${owner}/${repo}/${commit}`;
   const req = await axios.get(url, { authRequired: true });


### PR DESCRIPTION
This removes the manifest revision combo box, so we can use only the latest git commit of the xpi-manifests repo. 

I pushed the change to [staging](https://shipit.staging.mozilla-releng.net/newxpi) and this is how it looks like: https://img.lgtm.ca/6bec1602.png