### PR TITLE
Bug 1608874 - Remove Fennec now that the Fenix migration has started

### DIFF
--- a/api/src/shipit_api/admin/release.py
+++ b/api/src/shipit_api/admin/release.py
@@ -13,7 +13,6 @@ from shipit_api.common.product import Product
 # If version has two parts with no trailing specifiers like "rc", we
 # consider it a 'final' release for which we only create a _RELEASE tag.
 FINAL_RELEASE_REGEX = r"^\d+\.\d+$"
-_FENNEC_RC_REGEX = r"^68\.\d+\.0$"
 
 
 # TODO: Reland https://github.com/mozilla/release-services/pull/2262. It was backed out because of
@@ -42,10 +41,6 @@ def is_final_release(version):
     return bool(re.match(FINAL_RELEASE_REGEX, version))
 
 
-def _is_fennec_rc_release(product, version):
-    return product == "fennec_release" and bool(re.match(_FENNEC_RC_REGEX, version))
-
-
 def is_beta(version):
     return parse_version(version)["point"] == "b"
 
@@ -56,7 +51,7 @@ def is_esr(version):
 
 def is_rc(product, version, partial_updates):
     if not is_beta(version) and not is_esr(version):
-        if is_final_release(version) or _is_fennec_rc_release(product, version):
+        if is_final_release(version):
             # version supports rc flavor
             # now validate that the product itself supports rc flavor
             if SUPPORTED_FLAVORS.get(f"{product}_rc"):

--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -451,12 +451,6 @@ SUPPORTED_FLAVORS = {
         {"name": "push_firefox", "in_previous_graph_ids": True},
         {"name": "ship_firefox", "in_previous_graph_ids": True},
     ],
-    "fennec": [{"name": "promote_fennec", "in_previous_graph_ids": True}, {"name": "ship_fennec", "in_previous_graph_ids": True}],
-    "fennec_rc": [
-        {"name": "promote_fennec", "in_previous_graph_ids": True},
-        {"name": "ship_fennec_rc", "in_previous_graph_ids": True},
-        {"name": "ship_fennec", "in_previous_graph_ids": True},
-    ],
     "devedition": [
         {"name": "promote_devedition", "in_previous_graph_ids": True},
         {"name": "push_devedition", "in_previous_graph_ids": True},
@@ -466,12 +460,6 @@ SUPPORTED_FLAVORS = {
         {"name": "promote_thunderbird", "in_previous_graph_ids": True},
         {"name": "push_thunderbird", "in_previous_graph_ids": True},
         {"name": "ship_thunderbird", "in_previous_graph_ids": True},
-    ],
-    "fennec_release": [{"name": "promote_fennec_release", "in_previous_graph_ids": True}, {"name": "ship_fennec_release", "in_previous_graph_ids": True}],
-    "fennec_release_rc": [
-        {"name": "promote_fennec_release", "in_previous_graph_ids": True},
-        {"name": "ship_fennec_release_rc", "in_previous_graph_ids": True},
-        {"name": "ship_fennec_release", "in_previous_graph_ids": True},
     ],
     "fenix": [{"name": "ship", "in_previous_graph_ids": True}],
 }

--- a/api/tests/test_release.py
+++ b/api/tests/test_release.py
@@ -27,24 +27,13 @@ def test_is_esr(version, result):
     "product, version, partial_updates, result",
     (
         ("firefox", "41.0esr", None, False),
-        ("fennec", "56.0b3", None, False),
         ("firefox", "57.0", {"56.0b1": [], "55.0": []}, True),
         ("firefox", "57.0", {"56.0": [], "55.0": []}, True),
         ("thunderbird", "57.0", {"56.0": [], "55.0": []}, False),
         ("firefox", "64.0", None, True),
         ("thunderbird", "64.0", None, False),
-        ("fennec", "64.0", None, True),
         ("firefox", "64.0.1", None, False),
         ("thunderbird", "64.0.1", None, False),
-        # Fennec on the 68 branch is a special case
-        ("fennec_release", "68.0", None, True),
-        ("fennec_beta", "68.0b1", None, False),
-        ("fennec", "68.0b1", None, False),
-        ("fennec_release", "68.2.0", None, True),
-        ("fennec", "68.2.0", None, False),
-        ("fennec_release", "68.2.1", None, False),
-        ("fennec_release", "68.3.0", None, True),
-        ("fennec_release", "68.3.1", None, False),
     ),
 )
 def test_is_rc(product, version, partial_updates, result):

--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -36,44 +36,6 @@ module.exports = {
       canTogglePartials: true,
     },
     {
-      product: 'fennec',
-      prettyName: 'Firefox Mobile',
-      // TODO: The actual appName is `mobile/android` but it gets the version
-      // from `browser`.
-      appName: 'browser',
-      branches: [
-        {
-          prettyName: 'Maple Beta',
-          project: 'maple',
-          branch: 'projects/maple',
-          repo: 'https://hg.mozilla.org/projects/maple',
-          enableReleaseEta: false,
-          alternativeBranch: 'releases/mozilla-beta',
-          disableable: false,
-        },
-        {
-          prettyName: 'Try',
-          project: 'try',
-          branch: 'try',
-          repo: 'https://hg.mozilla.org/try',
-          enableReleaseEta: false,
-          disableable: false,
-        },
-        {
-          prettyName: 'Try Release',
-          project: 'maple',
-          branch: 'try',
-          repo: 'https://hg.mozilla.org/try',
-          enableReleaseEta: false,
-          productKey: 'fennec_release',
-          versionFile:
-            'mobile/android/config/version-files/release/version_display.txt',
-          disableable: false,
-        },
-      ],
-      enablePartials: false,
-    },
-    {
       product: 'devedition',
       prettyName: 'Firefox Developer Edition',
       appName: 'browser',

--- a/frontend/src/configs/development.js
+++ b/frontend/src/configs/development.js
@@ -36,35 +36,6 @@ module.exports = {
       canTogglePartials: true,
     },
     {
-      product: 'fennec',
-      prettyName: 'Firefox Mobile',
-      // TODO: The actual appName is `mobile/android` but it gets the version
-      // from `browser`.
-      appName: 'browser',
-      branches: [
-        {
-          prettyName: 'Maple Beta',
-          project: 'maple',
-          branch: 'projects/maple',
-          repo: 'https://hg.mozilla.org/projects/maple',
-          enableReleaseEta: false,
-          disableable: false,
-        },
-        {
-          prettyName: 'Try Release',
-          project: 'maple',
-          branch: 'try',
-          repo: 'https://hg.mozilla.org/try',
-          enableReleaseEta: false,
-          disableable: false,
-          productKey: 'fennec_release',
-          versionFile:
-            'mobile/android/config/version-files/release/version_display.txt',
-        },
-      ],
-      enablePartials: false,
-    },
-    {
       product: 'devedition',
       prettyName: 'Firefox Developer Edition',
       appName: 'browser',

--- a/frontend/src/configs/master.js
+++ b/frontend/src/configs/master.js
@@ -36,24 +36,6 @@ module.exports = {
       enablePartials: true,
     },
     {
-      product: 'fennec',
-      prettyName: 'Firefox Mobile',
-      // TODO: The actual appName is `mobile/android` but it gets the version
-      // from `browser`.
-      appName: 'browser',
-      branches: [
-        {
-          prettyName: 'Maple Beta',
-          project: 'maple',
-          branch: 'projects/maple',
-          repo: 'https://hg.mozilla.org/projects/maple',
-          enableReleaseEta: false,
-          disableable: false,
-        },
-      ],
-      enablePartials: false,
-    },
-    {
       product: 'devedition',
       prettyName: 'Firefox Developer Edition',
       appName: 'browser',

--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -61,26 +61,6 @@ module.exports = {
       enablePartials: true,
     },
     {
-      product: 'fennec',
-      prettyName: 'Firefox Mobile',
-      // TODO: The actual appName is `mobile/android` but it gets the version
-      // from `browser`.
-      appName: 'browser',
-      branches: [
-        {
-          prettyName: 'Release',
-          project: 'mozilla-esr68',
-          branch: 'releases/mozilla-esr68',
-          repo: 'https://hg.mozilla.org/releases/mozilla-esr68',
-          productKey: 'fennec_release',
-          versionFile:
-            'mobile/android/config/version-files/release/version_display.txt',
-          disableable: false,
-        },
-      ],
-      enablePartials: false,
-    },
-    {
       product: 'devedition',
       prettyName: 'Firefox Developer Edition',
       appName: 'browser',


### PR DESCRIPTION
Same as https://github.com/mozilla-releng/shipit/pull/156 but for release. 

I see there are plenty of references to Fennec in the code base. We may want to clean this up later. I think it's better to prevent shipping first. 