### PR TITLE
Add entry points for admin console scripts

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -11,7 +11,9 @@ COPY requirements/ /app/requirements/
 RUN pip install -r requirements/base.txt
 
 COPY . /app
-RUN APP_TYPE="admin" pip install -e .
+# Ideally this would be `pip install -e`, but that breaks
+# the entry points that we require
+RUN APP_TYPE="admin" pip install .
 
 ENV FLASK_APP shipit_api.admin.flask:app
 ENV WEB_CONCURRENCY=3

--- a/api/setup.py
+++ b/api/setup.py
@@ -45,6 +45,7 @@ test_requirements = ["pytest"]
 packages = find_packages("src", include=["backend_common", "cli_common"]) + find_namespace_packages("src", include=["shipit_api.common", "shipit_api.public"])
 name = "shipit_api-public"
 req_file = "public.txt"
+entry_points = None
 
 # In order to separate the public and admin apps, use `APP_TYPE` environment
 # variable as a most portable way to parameterize setup.py
@@ -52,6 +53,14 @@ if os.environ.get("APP_TYPE") == "admin":
     packages.extend(find_namespace_packages("src", include=["shipit_api.admin"]))
     name = "shipit_api-admin"
     req_file = "base.txt"
+    entry_points = {
+        "console_scripts": [
+            "shipit_upload_product_details = shipit_api.admin.cli:upload_product_details",
+            "shipit_rebuild_product_details = shipit_api.admin.cli:rebuild_product_details",
+            "shipit_import = shipit_api.admin.cli:shipit_import",
+            "shipit_trigger_product_details = shipit_api.admin.cli:trigger_product_details",
+        ]
+    }
 
 setup(
     author="Mozilla Release Engineering",
@@ -65,6 +74,7 @@ setup(
         "Programming Language :: Python :: 3.8",
     ],
     description="Ship It API",
+    entry_points=entry_points,
     install_requires=get_requirements(req_file),
     license="MPL2.0",
     long_description=readme + "\n\n" + history,

--- a/api/setup.py
+++ b/api/setup.py
@@ -55,7 +55,7 @@ if os.environ.get("APP_TYPE") == "admin":
     req_file = "base.txt"
     entry_points = {
         "console_scripts": [
-            "shipit_upload_product_details = shipit_api.admin.cli:upload_product_details",
+            "shipit_upload_product_details = shipit_api.admin.cli:download_product_details",
             "shipit_rebuild_product_details = shipit_api.admin.cli:rebuild_product_details",
             "shipit_import = shipit_api.admin.cli:shipit_import",
             "shipit_trigger_product_details = shipit_api.admin.cli:trigger_product_details",


### PR DESCRIPTION
This seems like it should work, but doesn't. We end up with errors such as:
```
root@7dc02f518db9:/app# upload_product_details 
Traceback (most recent call last):
  File "/usr/local/bin/upload_product_details", line 33, in <module>
    sys.exit(load_entry_point('shipit-api-admin', 'console_scripts', 'upload_product_details')())
  File "/usr/local/bin/upload_product_details", line 22, in importlib_load_entry_point
    for entry_point in distribution(dist_name).entry_points
  File "/usr/local/lib/python3.8/importlib/metadata.py", line 504, in distribution
    return Distribution.from_name(distribution_name)
  File "/usr/local/lib/python3.8/importlib/metadata.py", line 177, in from_name
    raise PackageNotFoundError(name)
importlib.metadata.PackageNotFoundError: shipit-api-admin
```

...for reasons that aren't clear to me.