### PR TITLE
add rdalal and mcooper to privileged build group

### DIFF
--- a/api/src/shipit_api/admin/settings.py
+++ b/api/src/shipit_api/admin/settings.py
@@ -66,6 +66,7 @@ ADMIN_GROUP = [
     "mtabara@mozilla.com",
 ]
 
+# Please ping awagner before making changes to this group
 XPI_PRIVILEGED_BUILD_GROUP = ["amarchesini@mozilla.com", "rdalal@mozilla.com", "mcooper@mozilla.com"]
 XPI_PRIVILEGED_ADMIN_GROUP = [
     "awagner@mozilla.com",

--- a/api/src/shipit_api/admin/settings.py
+++ b/api/src/shipit_api/admin/settings.py
@@ -66,7 +66,7 @@ ADMIN_GROUP = [
     "mtabara@mozilla.com",
 ]
 
-XPI_PRIVILEGED_BUILD_GROUP = ["amarchesini@mozilla.com"]
+XPI_PRIVILEGED_BUILD_GROUP = ["amarchesini@mozilla.com", "rdalal@mozilla.com", "mcooper@mozilla.com"]
 XPI_PRIVILEGED_ADMIN_GROUP = [
     "awagner@mozilla.com",
     "pkewisch@mozilla.com",


### PR DESCRIPTION
@wagnerand does this look ok?

We may also want to let the build-requester do the 1st signoff.