### PR TITLE
Turn partner builds on earlier in the beta cycle

### DIFF
--- a/api/src/shipit_api/admin/release.py
+++ b/api/src/shipit_api/admin/release.py
@@ -94,7 +94,7 @@ def is_partner_enabled(product, version, min_version=60):
     major_version = int(version.split(".")[0])
     if product == "firefox" and major_version >= min_version:
         if is_beta(version):
-            if get_beta_num(version) >= 8:
+            if get_beta_num(version) >= 5:
                 return True
         elif is_esr(version):
             return True


### PR DESCRIPTION
If I recall correctly, the original intent was to have partner builds on for roughly the latter have of the beta cycle, which meant we had them for b8 and above. Since we moved to a shorter beta cycle we haven't adjusted this - which means we have them on only for 2 betas per cycle now. I think it probably makes sense to enable them for b5 -- this will turn them on a week earlier, giving us a bit more time to find/fix issues.