### PR TITLE
Bump version & dates.

### DIFF
--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -46,17 +46,17 @@ ESR_BRANCH_PREFIX = "releases/mozilla-esr"
 # day).
 # We could have used the in-tree version, but there can be race conditions,
 # e.g. version bumped, but still no builds available.
-FIREFOX_NIGHTLY = "82.0a1"
+FIREFOX_NIGHTLY = "83.0a1"
 
 # The next 6 dates are information about the current and next release
 # They must be updated at the same time as FIREFOX_NIGHTLY
 # They can be found: https://wiki.mozilla.org/Release_Management/Calendar
-LAST_SOFTFREEZE_DATE = "2020-07-23"
-LAST_MERGE_DATE = "2020-08-24"
-LAST_RELEASE_DATE = "2020-08-25"
-NEXT_SOFTFREEZE_DATE = "2020-08-20"
-NEXT_MERGE_DATE = "2020-09-21"
-NEXT_RELEASE_DATE = "2020-09-22"
+LAST_SOFTFREEZE_DATE = "2020-09-17"
+LAST_MERGE_DATE = "2020-09-21"
+LAST_RELEASE_DATE = "2020-09-22"
+NEXT_SOFTFREEZE_DATE = "2020-10-15"
+NEXT_MERGE_DATE = "2020-10-19"
+NEXT_RELEASE_DATE = "2020-10-20"
 
 # Fennec Nightly users have been migrated to Fenix, thus we don't need to bump
 # the following numbers anymore.


### PR DESCRIPTION
AFAICT the soft freeze dates have been wrong for awhile, unless they're explicitly supposed to be one version behind the other dates.