### PR TITLE
Retire mozilla-esr68 from the config

### DIFF
--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -36,17 +36,6 @@ module.exports = {
           disableable: false,
         },
         {
-          prettyName: 'ESR68',
-          project: 'mozilla-esr68',
-          branch: 'releases/mozilla-esr68',
-          repo: 'https://hg.mozilla.org/releases/mozilla-esr68',
-          enableReleaseEta: true,
-          numberOfPartials: 5,
-          alternativeBranch: 'releases/mozilla-esr60',
-          alternativeRepo: 'https://hg.mozilla.org/releases/mozilla-esr60',
-          disableable: false,
-        },
-        {
           prettyName: 'ESR78',
           project: 'mozilla-esr78',
           branch: 'releases/mozilla-esr78',


### PR DESCRIPTION
the ESR68 branch reached EOL in September 2020.