### PR TITLE
Bug 1658553 - add Aryx to Firefox releases handling.

### DIFF
--- a/api/src/shipit_api/admin/settings.py
+++ b/api/src/shipit_api/admin/settings.py
@@ -99,7 +99,7 @@ XPI_MOZILLAONLINE_PRIVILEGED_ADMIN_GROUP = ["awagner@mozilla.com", "mkaply@mozil
 
 GROUPS = {
     "admin": ADMIN_GROUP,
-    "firefox-signoff": ["jcristau@mozilla.com", "pchevrel@mozilla.com", "rvandermeulen@mozilla.com"],
+    "firefox-signoff": ["jcristau@mozilla.com", "pchevrel@mozilla.com", "rvandermeulen@mozilla.com", "shengst@mozilla.com"],
     "fenix-signoff": ["jcristau@mozilla.com", "pchevrel@mozilla.com", "rvandermeulen@mozilla.com"],
     "thunderbird-signoff": ["vseerror@lehigh.edu", "mozilla@jorgk.com", "thunderbird@calypsoblue.org", "justdave@thunderbird.net"],
     # XPI signoffs. These are in flux.


### PR DESCRIPTION
As per bug 1658553, Aryx needs rights to:
* perform beta simulations via Ship-it (precisely http://docs.mozilla-releng.net/en/latest/procedures/release-duty/merge-duty/merge_duty.html#run-staging-releases)
* push to mirrors 

CC @jcristau @Archaeopteryx 