### PR TITLE
Bug 1568466 - Enable prod instance to ship Fenix releases

### DIFF
--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -99,6 +99,21 @@ module.exports = {
       ],
       enablePartials: true,
     },
+    {
+      product: 'fenix',
+      prettyName: 'Fenix',
+      appName: 'fenix',
+      branches: [],
+      repositories: [
+        {
+          prettyName: 'Official repo',
+          project: 'fenix',
+          repo: 'https://github.com/mozilla-mobile/fenix',
+          enableReleaseEta: false,
+        },
+      ],
+      enablePartials: false,
+    },
   ],
   XPI_MANIFEST: {
     branch: 'master',


### PR DESCRIPTION
I `git grep`'d a few things in the codebase to ensure we don't need anything else. But the backend doesn't make any assumptions what repos it's allowed to deal with. The fontend config drives it all.