### PR TITLE
Bug 1676110 - Update nightly version and release dates

### DIFF
--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -46,17 +46,17 @@ ESR_BRANCH_PREFIX = "releases/mozilla-esr"
 # day).
 # We could have used the in-tree version, but there can be race conditions,
 # e.g. version bumped, but still no builds available.
-FIREFOX_NIGHTLY = "84.0a1"
+FIREFOX_NIGHTLY = "85.0a1"
 
 # The next 6 dates are information about the current and next release
 # They must be updated at the same time as FIREFOX_NIGHTLY
 # They can be found: https://wiki.mozilla.org/Release_Management/Calendar
-LAST_SOFTFREEZE_DATE = "2020-10-15"
-LAST_MERGE_DATE = "2020-10-19"
-LAST_RELEASE_DATE = "2020-10-20"
-NEXT_SOFTFREEZE_DATE = "2020-11-12"
-NEXT_MERGE_DATE = "2020-11-16"
-NEXT_RELEASE_DATE = "2020-11-17"
+LAST_SOFTFREEZE_DATE = "2020-11-12"
+LAST_MERGE_DATE = "2020-11-16"
+LAST_RELEASE_DATE = "2020-11-16"
+NEXT_SOFTFREEZE_DATE = "2020-12-10"
+NEXT_MERGE_DATE = "2020-12-14"
+NEXT_RELEASE_DATE = "2020-12-15"
 
 # Fennec Nightly users have been migrated to Fenix, thus we don't need to bump
 # the following numbers anymore.


### PR DESCRIPTION
Today is merge day. 

This PR is part of the standard procedure. https://moz-releng-docs.readthedocs.io/en/latest/procedures/release-duty/merge-duty/merge_duty.html#bump-nightly-version-and-release-dates-in-shipit

This should be merged once the latest nightly builds have been published. They just started 30 minutes ago, so we can merge this later today. This will update this endpoint https://product-details.mozilla.org/1.0/firefox_versions.json.