### PR TITLE
Bug 1568466 - part 2: Fix Fenix production index

### DIFF
--- a/api/src/shipit_api/admin/tasks.py
+++ b/api/src/shipit_api/admin/tasks.py
@@ -48,12 +48,9 @@ def get_trust_domain(repo_url, project, product):
 def find_decision_task_id(repo_url, project, revision, product):
     trust_domain = get_trust_domain(repo_url, project, product)
     if trust_domain.endswith("mobile"):
-        # XXX "project" is a gecko-centric term which is translated into a branch in the git world.
-        branch = project
-        _, repo_name = extract_github_repo_owner_and_name(repo_url)
-        decision_task_route = f"{trust_domain}.v2.{repo_name}.branch.{branch}.revision.{revision}.taskgraph.decision"
-    else:
-        decision_task_route = f"{trust_domain}.v2.{project}.revision.{revision}.taskgraph.decision"
+        _, project = extract_github_repo_owner_and_name(repo_url)
+
+    decision_task_route = f"{trust_domain}.v2.{project}.revision.{revision}.taskgraph.decision"
     index = get_service("index")
     return index.findTask(decision_task_route)["taskId"]
 


### PR DESCRIPTION
Yesterday, I tried to kick off Fenix 84.0.0-beta.1 from shipit. It ended up failing this way: 

![image](https://user-images.githubusercontent.com/5907366/99684253-86769c00-2a81-11eb-88d4-0086cb51f953.png)

```
Error: Indexed task not found --- * method: findTask * errorCode: ResourceNotFound * statusCode: 404 * time: 2020-11-18T17:58:26.770Z
```

The request made by the front-end was 100% good:

```json
{
    "branch": "releases/v84.0.0",
    "build_number": 1,
    "product": "fenix",
    "repo_url": "https://github.com/mozilla-mobile/fenix",
    "revision": "3350114d0846a03c06149a3d35ef32bcb7a97da6",
    "version": "84.0.0-beta.1"
}
```

I couldn't understand why shipit couldn't find the decision task by its index. The decision task exposes:

```json
{
  "routes": [
    "checks",
    "tc-treeherder.v2.fenix.3350114d0846a03c06149a3d35ef32bcb7a97da6",
    "index.mobile.v2.fenix.branch.releases/v84.0.0.latest.taskgraph.decision",
    "index.mobile.v2.fenix.branch.releases/v84.0.0.revision.3350114d0846a03c06149a3d35ef32bcb7a97da6.taskgraph.decision",
    "index.mobile.v2.fenix.revision.3350114d0846a03c06149a3d35ef32bcb7a97da6.taskgraph.decision"
  ],
}
```

which is again 100% good. Thus, something was wrong with shipit. I didn't manage to get some interesting logs with this kind of request: https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0A%22fenix%22;timeRange=2020-11-18T17:00:00Z%2F2020-11-18T20:00:00Z?project=moz-fx-shipitapi-prod-5cb2. I'm guessing shipit doesn't log responses - including non-2xx ones - it returns. I didn't manage to see such logs when I reproduced the bug locally. 

I repro'd locally by flipping this single line 

https://github.com/mozilla-releng/shipit/blob/4bde10ef10cd9c061dd3e3a26aeb05eaa09e53b0/docker-compose.yml#L82

to 

```yaml
      - DEPLOYMENT_BRANCH=production
```

Then the error was obvious. The code I wrote[1] at the beginning of the project "Fenix on shipit" had never been tested on production. Moreover, it was written at a time where I thought the index `index.mobile.v2.fenix.revision.{rev}.taskgraph.decision` shouldn't be used because of a potential hash collision between branches. That said, that index is needed by other tools, so I ended up adding it[2].

Hence, this PR simplify the logic I wrote in #124 to fix Fenix in production. I tested this patch locally and it works.

[1] https://github.com/mozilla-releng/shipit/pull/124/files#diff-443c5fbe6b670e4946132902c18ab6e02b8f259cd2d01953ccc35ac6c5e12e7eR47
[2] https://github.com/mozilla-mobile/fenix/pull/10644