### PR TITLE
Bug 1679399 - Use mozilla-version to parse and bump version numbers

### DIFF
--- a/api/src/shipit_api/admin/api.py
+++ b/api/src/shipit_api/admin/api.py
@@ -87,7 +87,7 @@ def add_release(body):
         version=body["version"],
     )
     try:
-        next_version = bump_version(release.version.replace("esr", ""))
+        next_version = bump_version(release.product, release.version)
         common_input = {
             "build_number": release.build_number,
             "next_version": next_version,

--- a/api/src/shipit_api/admin/release.py
+++ b/api/src/shipit_api/admin/release.py
@@ -3,113 +3,97 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import re
-
 import requests
+from mozilla_version.fenix import FenixVersion  # TODO Move FenixVersion into mozilla.gecko
+from mozilla_version.gecko import DeveditionVersion, FennecVersion, FirefoxVersion, ThunderbirdVersion
 
 from shipit_api.common.config import SUPPORTED_FLAVORS
 from shipit_api.common.product import Product
 
-# If version has two parts with no trailing specifiers like "rc", we
-# consider it a 'final' release for which we only create a _RELEASE tag.
-FINAL_RELEASE_REGEX = r"^\d+\.\d+$"
+_VERSION_CLASS_PER_PRODUCT = {
+    Product.DEVEDITION: DeveditionVersion,
+    Product.FENIX: FenixVersion,
+    Product.FENNEC: FennecVersion,
+    Product.FIREFOX: FirefoxVersion,
+    Product.THUNDERBIRD: ThunderbirdVersion,
+}
 
 
-# TODO: Reland https://github.com/mozilla/release-services/pull/2262. It was backed out because of
-# https://github.com/mozilla/release-services/pull/2265#issue-317003960
-VERSION_REGEX = re.compile(
-    r"^"
-    r"(?P<major_minor>[0-9]+\.[0-9]+)"  # Major and minor version
-    r"(?:"  # Patch or beta version is optional
-    r"(?P<point>[.ba])"  # Separator from patch or beta version
-    r"(?P<patch>[0-9]+)"  # Patch or beta version
-    r")?"
-    r"(?P<esr>(?:esr)?)"  # ESR indicator
-    r"(-beta\.(?P<semver_beta>[0-9]+))?"  # Semver beta number (used in Fenix)
-    r"$"
-)
+def parse_version(product, version):
+    if isinstance(product, Product):
+        product_enum = product
+    else:
+        try:
+            product_enum = Product[product.upper()]
+        except KeyError:
+            raise ValueError(f"Product {product} versions are not supported")
 
-
-def parse_version(version):
-    match = VERSION_REGEX.match(version)
-    if not match:
-        raise Exception("Unknown version format.")
-    return match.groupdict()
-
-
-def is_final_release(version):
-    return bool(re.match(FINAL_RELEASE_REGEX, version))
-
-
-def is_beta(version):
-    return parse_version(version)["point"] == "b"
-
-
-def is_esr(version):
-    return parse_version(version)["esr"] == "esr"
+    VersionClass = _VERSION_CLASS_PER_PRODUCT[product_enum]
+    return VersionClass.parse(version)
 
 
 def is_rc(product, version, partial_updates):
-    if not is_beta(version) and not is_esr(version):
-        if is_final_release(version):
-            # version supports rc flavor
-            # now validate that the product itself supports rc flavor
-            if SUPPORTED_FLAVORS.get(f"{product}_rc"):
-                # could hard code "Thunderbird" condition here but
-                # suspect it's better to use SUPPORTED_FLAVORS for a
-                # configuration driven decision.
+    gecko_version = parse_version(product, version)
+
+    # Release candidates are only expected when the version number matches
+    # the release pattern
+
+    if not gecko_version.is_release or gecko_version.patch_number is not None:
+        return False
+
+    if SUPPORTED_FLAVORS.get(f"{product}_rc"):
+        # could hard code "Thunderbird" condition here but
+        # suspect it's better to use SUPPORTED_FLAVORS for a
+        # configuration driven decision.
+        return True
+
+    # RC release types will enable beta-channel testing &
+    # shipping. We need this for all "final" releases
+    # and also any releases that include a beta as a partial.
+    # The assumption that "shipping to beta channel" always
+    # implies other RC behaviour is bound to break at some
+    # point, but this works for now.
+    if partial_updates:
+        for partial_version in partial_updates:
+            partial_gecko_version = parse_version(product, partial_version)
+            if partial_gecko_version.is_beta:
                 return True
-        # RC release types will enable beta-channel testing &
-        # shipping. We need this for all "final" releases
-        # and also any releases that include a beta as a partial.
-        # The assumption that "shipping to beta channel" always
-        # implies other RC behaviour is bound to break at some
-        # point, but this works for now.
-        if partial_updates:
-            for version in partial_updates:
-                if is_beta(version):
-                    return True
+
     return False
 
 
-def bump_version(version):
+def bump_version(product, version):
     """Bump last digit"""
-    parts = parse_version(version)
-    if parts["patch"]:
-        parts["patch"] = int(parts["patch"]) + 1
-    else:
-        parts["patch"] = 1
-    if not parts["point"]:
-        parts["point"] = "."
-    return f'{parts["major_minor"]}{parts["point"]}{parts["patch"]}{parts["esr"]}'
-
-
-def get_beta_num(version):
-    if is_beta(version):
-        parts = version.split("b")
-        return int(parts[-1])
+    gecko_version = parse_version(product, version)
+    number_to_bump = "beta_number" if gecko_version.is_beta else "patch_number"
+    bumped_version = gecko_version.bump(number_to_bump)
+    return str(bumped_version)
 
 
 def is_partner_enabled(product, version, min_version=60):
-    major_version = int(version.split(".")[0])
-    if product == "firefox" and major_version >= min_version:
-        if is_beta(version):
-            if get_beta_num(version) >= 5:
-                return True
-        elif is_esr(version):
-            return True
-        else:
-            return True
+    if product == "firefox":
+        firefox_version = FirefoxVersion.parse(version)
+        return firefox_version.major_number >= min_version and any(
+            (
+                firefox_version.is_beta and firefox_version.beta_number >= 8,
+                firefox_version.is_release,
+                firefox_version.is_esr,
+            )
+        )
+
     return False
 
 
 def is_eme_free_enabled(product, version):
     if product == "firefox":
-        if is_beta(version):
-            if get_beta_num(version) >= 8:
-                return True
-        elif not is_esr(version):
-            return True
+        firefox_version = FirefoxVersion.parse(version)
+        return any(
+            (
+                firefox_version.is_beta and firefox_version.beta_number >= 8,
+                firefox_version.is_release,
+            )
+        )
+
     return False
 
 

--- a/api/tests/test_release.py
+++ b/api/tests/test_release.py
@@ -3,37 +3,60 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from contextlib import nullcontext as does_not_raise
+
 import pytest
+from mozilla_version.fenix import FenixVersion
+from mozilla_version.gecko import DeveditionVersion, FennecVersion, FirefoxVersion, ThunderbirdVersion
 
-from shipit_api.admin.release import bump_version, is_beta, is_eme_free_enabled, is_esr, is_final_release, is_partner_enabled, is_rc
-
-
-@pytest.mark.parametrize("version, result", (("57.0", True), ("7.0", True), ("123.0", True), ("56.0b3", False), ("41.0esr", False), ("78.0.1", False)))
-def test_is_final_version(version, result):
-    assert is_final_release(version) == result
+from shipit_api.admin.release import bump_version, is_eme_free_enabled, is_partner_enabled, is_rc, parse_version
+from shipit_api.common.product import Product
 
 
-@pytest.mark.parametrize("version, result", (("57.0", False), ("7.0", False), ("123.0", False), ("56.0b3", True), ("41.0esr", False), ("78.0.1", False)))
-def test_is_beta(version, result):
-    assert is_beta(version) == result
-
-
-@pytest.mark.parametrize("version, result", (("57.0", False), ("7.0", False), ("123.0", False), ("56.0b3", False), ("41.0esr", True), ("78.0.1", False)))
-def test_is_esr(version, result):
-    assert is_esr(version) == result
+@pytest.mark.parametrize(
+    "product, version, expectation, result",
+    (
+        ("devedition", "56.0b1", does_not_raise(), DeveditionVersion(56, 0, beta_number=1)),
+        (Product.DEVEDITION, "56.0b1", does_not_raise(), DeveditionVersion(56, 0, beta_number=1)),
+        ("fenix", "84.0.0-beta.2", does_not_raise(), FenixVersion(84, 0, 0, beta_number=2)),
+        (Product.FENIX, "84.0.0", does_not_raise(), FenixVersion(84, 0, 0)),
+        ("fennec", "68.2b3", does_not_raise(), FennecVersion(68, 2, beta_number=3)),
+        (Product.FENNEC, "68.2b3", does_not_raise(), FennecVersion(68, 2, beta_number=3)),
+        ("firefox", "45.0", does_not_raise(), FirefoxVersion(45, 0)),
+        (Product.FIREFOX, "45.0", does_not_raise(), FirefoxVersion(45, 0)),
+        ("thunderbird", "60.8.0", does_not_raise(), ThunderbirdVersion(60, 8, 0)),
+        (Product.THUNDERBIRD, "60.8.0", does_not_raise(), ThunderbirdVersion(60, 8, 0)),
+        ("non-existing-product", "68.0", pytest.raises(ValueError), None),
+        # fennec_release used to be a valid value when we moved Fennec to ESR68
+        # https://github.com/mozilla/release-services/pull/2265
+        # Let's be explicitly failing about it.
+        ("fennec_release", "68.1.1", pytest.raises(ValueError), None),
+    ),
+)
+def test_parse_version(product, version, expectation, result):
+    with expectation:
+        assert parse_version(product, version) == result
 
 
 @pytest.mark.parametrize(
     "product, version, partial_updates, result",
     (
-        ("firefox", "41.0esr", None, False),
-        ("firefox", "57.0", {"56.0b1": [], "55.0": []}, True),
-        ("firefox", "57.0", {"56.0": [], "55.0": []}, True),
-        ("thunderbird", "57.0", {"56.0": [], "55.0": []}, False),
         ("firefox", "64.0", None, True),
         ("thunderbird", "64.0", None, False),
+        ("fennec", "64.0", None, False),  # "fennec_rc" does not exist anymore
         ("firefox", "64.0.1", None, False),
         ("thunderbird", "64.0.1", None, False),
+        ("fennec", "64.0.1", None, False),
+        ("firefox", "56.0b3", None, False),
+        ("fennec", "56.0b3", None, False),
+        ("firefox", "45.0esr", None, False),
+        ("firefox", "57.0", {"56.0b1": [], "55.0": []}, True),
+        ("firefox", "57.0", {"56.0": [], "55.0": []}, True),
+        ("firefox", "57.0.1", {"57.0": [], "56.0.1": [], "56.0": []}, False),
+        ("thunderbird", "57.0", {"56.0": [], "55.0": []}, False),
+        ("thunderbird", "57.0", {"56.0": [], "56.0b4": [], "55.0": []}, True),
+        ("firefox", "70.0b4", {"69.0b15": [], "69.0b16": [], "70.0b3": []}, False),
+        ("devedition", "70.0b4", {"70.0b3": [], "70.0b1": [], "70.0b2": []}, False),
     ),
 )
 def test_is_rc(product, version, partial_updates, result):
@@ -41,11 +64,21 @@ def test_is_rc(product, version, partial_updates, result):
 
 
 @pytest.mark.parametrize(
-    "version, result",
-    (("45.0", "45.0.1"), ("45.0.1", "45.0.2"), ("45.0b3", "45.0b4"), ("45.0esr", "45.0.1esr"), ("45.0.1esr", "45.0.2esr"), ("45.2.1esr", "45.2.2esr")),
+    "product, version, result",
+    (
+        ("firefox", "45.0", "45.0.1"),
+        ("firefox", "45.0.1", "45.0.2"),
+        ("firefox", "45.0b3", "45.0b4"),
+        ("firefox", "45.0esr", "45.0.1esr"),
+        ("firefox", "45.0.1esr", "45.0.2esr"),
+        ("firefox", "45.2.1esr", "45.2.2esr"),
+        ("fennec", "68.1b2", "68.1b3"),
+        ("fenix", "84.0.0-beta.2", "84.0.0-beta.3"),
+        ("fenix", "84.0.0", "84.0.1"),
+    ),
 )
-def test_bump_version(version, result):
-    assert bump_version(version) == result
+def test_bump_version(product, version, result):
+    assert bump_version(product, version) == result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Relands https://github.com/mozilla/release-services/pull/2262 and https://github.com/mozilla/release-services/pull/2231