### PR TITLE
Allow shipit to bump fenix release candidates

### DIFF
--- a/api/tests/test_release.py
+++ b/api/tests/test_release.py
@@ -74,6 +74,7 @@ def test_is_rc(product, version, partial_updates, result):
         ("firefox", "45.2.1esr", "45.2.2esr"),
         ("fennec", "68.1b2", "68.1b3"),
         ("fenix", "84.0.0-beta.2", "84.0.0-beta.3"),
+        ("fenix", "84.0.0-rc.1", "84.0.0-rc.2"),
         ("fenix", "84.0.0", "84.0.1"),
     ),
 )


### PR DESCRIPTION
Yesterday, we shipped our first Fenix release candidate through shipit. The generated task[1] contains a wrong payload. We bumped the version number from `84.1.0-rc.1`to `84.1.1`:

```json
    "ACTION_INPUT": "{\"build_number\":2,\"next_version\":\"84.1.1\",\"previous_graph_ids\":[\"O7k8W3W-RTSjc-CP2hSORA\"],\"release_enable_emefree\":false,\"release_enable_partner_attribution\":false,\"release_enable_partner_repack\":false,\"release_eta\":null,\"release_promotion_flavor\":\"ship\",\"version\":\"84.1.0-rc.1\"}",
```

It should have been `84.1.0-rc.2` 

This conflicts a little bit with https://github.com/mozilla-releng/shipit/pull/547. I'm porting the changes I suggested in https://github.com/mozilla-releng/shipit/pull/547/files#r537688043 in this separate PR so we can quickly fix this in case we have an RC2 coming up soon.

cc @camd @escapewindow 

[1] https://firefox-ci-tc.services.mozilla.com/tasks/Nr6GV_eZQ2mGxzdPG09g8g