### PR TITLE
RELENG-147 - Enable production instance to ship android-components

### DIFF
--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -114,6 +114,21 @@ module.exports = {
       ],
       enablePartials: false,
     },
+    {
+      product: 'android-components',
+      prettyName: 'Android-Components',
+      appName: 'android-components',
+      branches: [],
+      repositories: [
+        {
+          prettyName: 'Official repo',
+          project: 'android-components',
+          repo: 'https://github.com/mozilla-mobile/android-components',
+          enableReleaseEta: false,
+        },
+      ],
+      enablePartials: false,
+    },
   ],
   XPI_MANIFEST: {
     branch: 'master',


### PR DESCRIPTION
Same as #525 but for Android-Components