### PR TITLE
Show Fenix & Android Components Releases on "Recent Releases" view (fixes #620)

### DIFF
--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -81,7 +81,11 @@ module.exports = {
       product: 'fenix',
       prettyName: 'Fenix',
       appName: 'fenix',
-      branches: [],
+      branches: [
+        {
+          branch: '',
+        },
+      ],
       repositories: [
         {
           prettyName: 'Staging fork',
@@ -96,7 +100,11 @@ module.exports = {
       product: 'android-components',
       prettyName: 'Android-Components',
       appName: 'android-components',
-      branches: [],
+      branches: [
+        {
+          branch: '',
+        },
+      ],
       repositories: [
         {
           prettyName: 'Staging fork',

--- a/frontend/src/configs/development.js
+++ b/frontend/src/configs/development.js
@@ -72,7 +72,11 @@ module.exports = {
       product: 'fenix',
       prettyName: 'Fenix',
       appName: 'fenix',
-      branches: [],
+      branches: [
+        {
+          branch: '',
+        },
+      ],
       repositories: [
         {
           prettyName: 'Staging fork',
@@ -87,7 +91,11 @@ module.exports = {
       product: 'android-components',
       prettyName: 'Android-Components',
       appName: 'android-components',
-      branches: [],
+      branches: [
+        {
+          branch: '',
+        },
+      ],
       repositories: [
         {
           prettyName: 'Staging fork',

--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -103,7 +103,11 @@ module.exports = {
       product: 'fenix',
       prettyName: 'Fenix',
       appName: 'fenix',
-      branches: [],
+      branches: [
+        {
+          branch: '',
+        },
+      ],
       repositories: [
         {
           prettyName: 'Official repo',
@@ -118,7 +122,11 @@ module.exports = {
       product: 'android-components',
       prettyName: 'Android-Components',
       appName: 'android-components',
-      branches: [],
+      branches: [
+        {
+          branch: '',
+        },
+      ],
       repositories: [
         {
           prettyName: 'Official repo',


### PR DESCRIPTION
This view currently assumes that Releases have "branches" defined --
which is not currently the case for these products. This is a hacky for
that. The better fix would be change that code to make that assumption,
but I don't have time to do that at the moment.