### PR TITLE
add an lru_cache to xpi manifest github calls

### DIFF
--- a/api/src/shipit_api/admin/github.py
+++ b/api/src/shipit_api/admin/github.py
@@ -1,4 +1,5 @@
 import json
+from functools import lru_cache
 from urllib.parse import unquote, urlparse
 
 import requests
@@ -18,6 +19,7 @@ def _require_auth():
         abort(401, f"required permission: {required_permission}, user permissions: {user_permissions}")
 
 
+@lru_cache(maxsize=10)
 def get_file_from_github(owner, repo, file_path, ref):
     query = """query {
       repository(owner:"%(owner)s", name:"%(repo)s") {


### PR DESCRIPTION
Our constant lookups may be causing problems:

![image](https://user-images.githubusercontent.com/826343/107459713-9f846b80-6b0b-11eb-8cac-1c49fa02e81d.png)

I had this lru_cache patch lying around. I pushed it to production to try to fix the bustage, but we should merge it properly.

**[EDIT]** still broken, but probably good to take anyway.