### PR TITLE
[RELENG-400] add directory support, take 2

### DIFF
--- a/api/src/shipit_api/admin/api.yml
+++ b/api/src/shipit_api/admin/api.yml
@@ -413,7 +413,7 @@ paths:
   /github/package_json/{owner}/{repo}/{revision}/{directory}:
     get:
       summary: Returns contents of package.json from a github repo's root directory
-      operationId: shipit_api.admin.github.get_package_json
+      operationId: shipit_api.admin.github.get_package_json_directory
       parameters:
       - name: owner
         in: path

--- a/api/src/shipit_api/admin/api.yml
+++ b/api/src/shipit_api/admin/api.yml
@@ -410,6 +410,42 @@ paths:
             application/json:
               schema:
                 type: object
+  /github/package_json/{owner}/{repo}/{revision}/{directory}:
+    get:
+      summary: Returns contents of package.json from a github repo's root directory
+      operationId: shipit_api.admin.github.get_package_json
+      parameters:
+      - name: owner
+        in: path
+        required: true
+        description: repo owner
+        schema:
+          type: string
+      - name: repo
+        in: path
+        required: true
+        description: repo name
+        schema:
+          type: string
+      - name: revision
+        in: path
+        required: true
+        description: commit revision
+        schema:
+          type: string
+      - name: directory
+        in: path
+        required: true
+        description: directory path
+        schema:
+          type: string
+      responses:
+        200:
+          description: Contents of package.json
+          content:
+            application/json:
+              schema:
+                type: object
   /github/version_txt/{owner}/{repo}/{revision}:
     get:
       summary: Returns contents of version.txt from a github repo's root directory

--- a/api/src/shipit_api/admin/github.py
+++ b/api/src/shipit_api/admin/github.py
@@ -196,7 +196,7 @@ def get_package_json(owner, repo, revision, directory=None):
         package = json.loads(get_file_from_github(owner, repo, path, revision))
         return package
     except TypeError as exc:
-        current_app.logger.error(f"Can't load package.json from {owner} {repo} {path} {revision}")
+        current_app.logger.error(f"Can't load package.json from {owner} {repo} {path} {revision}: {exc}")
         raise
 
 

--- a/api/src/shipit_api/admin/github.py
+++ b/api/src/shipit_api/admin/github.py
@@ -232,6 +232,7 @@ def list_xpis(owner, repo, revision):
                     "owner": xpi_owner,
                     "repo": xpi_repo,
                     "manifest_revision": revision,
+                    "directory": xpi.get("directory", ""),
                     "addon-type": xpi["addon-type"],
                 }
             )

--- a/api/src/shipit_api/admin/github.py
+++ b/api/src/shipit_api/admin/github.py
@@ -199,6 +199,9 @@ def get_package_json(owner, repo, revision, directory=None):
         current_app.logger.error(f"Can't load package.json from {owner} {repo} {path} {revision}: {exc}")
         raise
 
+def get_package_json_directory(owner, repo, revision, directory):
+    return get_package_json(owner, repo, revision, directory=directory)
+
 
 def get_version_txt(owner, repo, revision):
     return get_file_from_github(owner, repo, "version.txt", revision)

--- a/api/src/shipit_api/admin/github.py
+++ b/api/src/shipit_api/admin/github.py
@@ -199,6 +199,7 @@ def get_package_json(owner, repo, revision, directory=None):
         current_app.logger.error(f"Can't load package.json from {owner} {repo} {path} {revision}: {exc}")
         raise
 
+
 def get_package_json_directory(owner, repo, revision, directory):
     return get_package_json(owner, repo, revision, directory=directory)
 

--- a/api/src/shipit_api/admin/github.py
+++ b/api/src/shipit_api/admin/github.py
@@ -6,6 +6,7 @@ import requests
 import yaml
 from flask import abort, current_app
 from flask_login import current_user
+from sentry_sdk import capture_exception
 
 from shipit_api.common.config import SCOPE_PREFIX
 
@@ -236,8 +237,8 @@ def list_xpis(owner, repo, revision):
                     "addon-type": xpi["addon-type"],
                 }
             )
-        except TypeError:
-            continue
+        except TypeError as exc:
+            capture_exception(exc)
 
     return {"xpis": xpis}
 

--- a/api/src/shipit_api/admin/github.py
+++ b/api/src/shipit_api/admin/github.py
@@ -1,5 +1,4 @@
 import json
-import os
 from functools import lru_cache
 from urllib.parse import unquote, urlparse
 
@@ -192,7 +191,7 @@ def get_taskgraph_config(owner, repo, ref):
 def get_package_json(owner, repo, revision, directory=None):
     path = "package.json"
     if directory:
-        path = os.path.join(directory, path)
+        path = f"{directory.rstrip('/')}/{path}"
     package = json.loads(get_file_from_github(owner, repo, path, revision))
     return package
 

--- a/frontend/src/components/vcs.js
+++ b/frontend/src/components/vcs.js
@@ -49,22 +49,14 @@ export async function getXpis(owner, repo, commit) {
   return req.data;
 }
 
-export async function getXPIVersion(owner, repo, commit, directory) {
-  let url;
-
+export async function getXPIVersion(owner, repo, commit, directory=None) {
+  let url = `/github/package_json/${owner}/${repo}/${commit}`;
   if (directory) {
-    url = `/github/${directory}/package_json/${owner}/${repo}/${commit}`;
-  } else {
-    url = `/github/package_json/${owner}/${repo}/${commit}`;
+    url = `$url/${directory}`
   }
-
   const req = await axios.get(url, { authRequired: true });
 
-  try {
-    return req.data.version;
-  } catch (e) {
-    return `${url} is BROKEN`;
-  }
+  return req.data.version;
 }
 
 async function getHgPushes(repo) {

--- a/frontend/src/components/vcs.js
+++ b/frontend/src/components/vcs.js
@@ -60,7 +60,11 @@ export async function getXPIVersion(owner, repo, commit, directory) {
 
   const req = await axios.get(url, { authRequired: true });
 
-  return req.data.version;
+  try {
+    return req.data.version;
+  } catch (e) {
+    return 'BROKEN';
+  }
 }
 
 async function getHgPushes(repo) {

--- a/frontend/src/components/vcs.js
+++ b/frontend/src/components/vcs.js
@@ -49,8 +49,15 @@ export async function getXpis(owner, repo, commit) {
   return req.data;
 }
 
-export async function getXPIVersion(owner, repo, commit) {
-  const url = `/github/package_json/${owner}/${repo}/${commit}`;
+export async function getXPIVersion(owner, repo, commit, directory) {
+  let url;
+
+  if (directory) {
+    url = `/github/${directory}/package_json/${owner}/${repo}/${commit}`;
+  } else {
+    url = `/github/package_json/${owner}/${repo}/${commit}`;
+  }
+
   const req = await axios.get(url, { authRequired: true });
 
   return req.data.version;

--- a/frontend/src/components/vcs.js
+++ b/frontend/src/components/vcs.js
@@ -49,11 +49,13 @@ export async function getXpis(owner, repo, commit) {
   return req.data;
 }
 
-export async function getXPIVersion(owner, repo, commit, directory=None) {
+export async function getXPIVersion(owner, repo, commit, directory = null) {
   let url = `/github/package_json/${owner}/${repo}/${commit}`;
+
   if (directory) {
-    url = `$url/${directory}`
+    url = `$url/${directory}`;
   }
+
   const req = await axios.get(url, { authRequired: true });
 
   return req.data.version;

--- a/frontend/src/components/vcs.js
+++ b/frontend/src/components/vcs.js
@@ -63,7 +63,7 @@ export async function getXPIVersion(owner, repo, commit, directory) {
   try {
     return req.data.version;
   } catch (e) {
-    return 'BROKEN';
+    return `${url} is BROKEN`;
   }
 }
 

--- a/frontend/src/components/vcs.js
+++ b/frontend/src/components/vcs.js
@@ -53,7 +53,7 @@ export async function getXPIVersion(owner, repo, commit, directory = null) {
   let url = `/github/package_json/${owner}/${repo}/${commit}`;
 
   if (directory) {
-    url = `$url/${directory}`;
+    url = `${url}/${directory}`;
   }
 
   const req = await axios.get(url, { authRequired: true });

--- a/frontend/src/views/NewXPIRelease/index.jsx
+++ b/frontend/src/views/NewXPIRelease/index.jsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export default function NewXPIelease() {
+export default function NewXPIRelease() {
   const classes = useStyles();
   const [manifestCommit, fetchManifestCommit] = useAction(
     getLatestGithubCommit

--- a/frontend/src/views/NewXPIRelease/index.jsx
+++ b/frontend/src/views/NewXPIRelease/index.jsx
@@ -136,7 +136,8 @@ export default function NewXPIRelease() {
       await fetchXpiVersion(
         selectedXpi.owner,
         selectedXpi.repo,
-        selectedXpi.revision
+        selectedXpi.revision,
+        selectedXpi.directory
       )
     ).data;
     const buildNumber = await guessBuildNumber(selectedXpi.xpi_name, version);


### PR DESCRIPTION
Currently failing with

```
Uncaught (in promise) TypeError: r.data is null
    y https://shipit.staging.mozilla-releng.net/assets/NewXPIRelease.34b139af.js:1
    y https://shipit.staging.mozilla-releng.net/assets/NewXPIRelease.34b139af.js:1
    is https://shipit.staging.mozilla-releng.net/assets/7.eb9098a0.js:34
    gl https://shipit.staging.mozilla-releng.net/assets/7.eb9098a0.js:34
    unstable_runWithPriority https://shipit.staging.mozilla-releng.net/assets/7.eb9098a0.js:42
    ji https://shipit.staging.mozilla-releng.net/assets/7.eb9098a0.js:34
    fl https://shipit.staging.mozilla-releng.net/assets/7.eb9098a0.js:34
    ml https://shipit.staging.mozilla-releng.net/assets/7.eb9098a0.js:34
    B https://shipit.staging.mozilla-releng.net/assets/7.eb9098a0.js:42
    onmessage https://shipit.staging.mozilla-releng.net/assets/7.eb9098a0.js:42
    EventHandlerNonNull* https://shipit.staging.mozilla-releng.net/assets/7.eb9098a0.js:42
    u https://shipit.staging.mozilla-releng.net/assets/runtime.8239760b.js:1
    <anonymous> https://shipit.staging.mozilla-releng.net/assets/7.eb9098a0.js:34
    u https://shipit.staging.mozilla-releng.net/assets/runtime.8239760b.js:1
    <anonymous> https://shipit.staging.mozilla-releng.net/assets/7.eb9098a0.js:34
    u https://shipit.staging.mozilla-releng.net/assets/runtime.8239760b.js:1
    <anonymous> https://shipit.staging.mozilla-releng.net/assets/7.eb9098a0.js:1
    u https://shipit.staging.mozilla-releng.net/assets/runtime.8239760b.js:1
    455 https://shipit.staging.mozilla-releng.net/assets/index.7407bfac.js:1
    u https://shipit.staging.mozilla-releng.net/assets/runtime.8239760b.js:1
    158 https://shipit.staging.mozilla-releng.net/assets/index.7407bfac.js:1
    u https://shipit.staging.mozilla-releng.net/assets/runtime.8239760b.js:1
    t https://shipit.staging.mozilla-releng.net/assets/runtime.8239760b.js:1
    r https://shipit.staging.mozilla-releng.net/assets/runtime.8239760b.js:1
    <anonymous> https://shipit.staging.mozilla-releng.net/assets/index.7407bfac.js:1
NewXPIRelease.34b139af.js:1:1430
```

Running out of ideas. I'd love to see line numbers without munging the source =\