### PR TITLE
Revision link

### DIFF
--- a/frontend/src/components/ReleaseProgress/index.jsx
+++ b/frontend/src/components/ReleaseProgress/index.jsx
@@ -19,7 +19,6 @@ import ReleaseContext from '../../utils/ReleaseContext';
 import { AuthContext } from '../../utils/AuthContext';
 import config from '../../config';
 import { repoUrlBuilder } from '../../utils/helpers';
-import { XPI_MANIFEST_REPO } from '../../utils/constants';
 
 const useStyles = makeStyles(() => ({
   cardActions: {
@@ -114,7 +113,7 @@ export default function ReleaseProgress({
     }
 
     if (isXPI) {
-      url = repoUrlBuilder(XPI_MANIFEST_REPO, release.revision);
+      url = repoUrlBuilder(config.XPI_MANIFEST.repo, release.revision);
     } else if (productBranch && productBranch.repo) {
       url = repoUrlBuilder(productBranch.repo, release.revision);
     }

--- a/frontend/src/components/ReleaseProgress/index.jsx
+++ b/frontend/src/components/ReleaseProgress/index.jsx
@@ -93,10 +93,10 @@ export default function ReleaseProgress({
   const renderReleaseTitle = (isXPI, release) => {
     let url = null;
     let productBranch = null;
+    const { PRODUCTS, XPI_MANIFEST, TREEHERDER_URL } = config;
     const trimmedRevision = release.revision.substring(0, 13);
-    const product = config.PRODUCTS.find(
-      product => product.product === release.product
-    );
+    const product =
+      PRODUCTS && PRODUCTS.find(product => product.product === release.product);
 
     if (product && product.branches) {
       productBranch = product.branches.find(
@@ -112,8 +112,8 @@ export default function ReleaseProgress({
       );
     }
 
-    if (isXPI) {
-      url = repoUrlBuilder(config.XPI_MANIFEST.repo, release.revision);
+    if (isXPI && XPI_MANIFEST.repo) {
+      url = repoUrlBuilder(XPI_MANIFEST.repo, release.revision);
     } else if (productBranch && productBranch.repo) {
       url = repoUrlBuilder(productBranch.repo, release.revision);
     }
@@ -128,13 +128,13 @@ export default function ReleaseProgress({
           trimmedRevision
         )}
 
-        {!isXPI && (
+        {!isXPI && TREEHERDER_URL && (
           <span>
             {' '}
             .{' '}
             <Link
               target="_blank"
-              href={`${config.TREEHERDER_URL}/jobs?repo=${release.project}&revision=${release.revision}`}>
+              href={`${TREEHERDER_URL}/jobs?repo=${release.project}&revision=${release.revision}`}>
               View in Treeherder
             </Link>
           </span>

--- a/frontend/src/components/ReleaseProgress/index.jsx
+++ b/frontend/src/components/ReleaseProgress/index.jsx
@@ -93,21 +93,29 @@ export default function ReleaseProgress({
 
   const renderReleaseTitle = (isXPI, release) => {
     let url = null;
+    let productBranch = null;
     const trimmedRevision = release.revision.substring(0, 13);
     const product = config.PRODUCTS.find(
       product => product.product === release.product
     );
-    const productBranch =
-      product && product.branches
-        ? product.branches.find(
-            item =>
-              item.branch === release.branch && item.project === release.project
-          )
-        : null;
+
+    if (product && product.branches) {
+      productBranch = product.branches.find(
+        item =>
+          item.branch === release.branch && item.project === release.project
+      );
+    }
+
+    // non-hg or firefox projects are formatted differently in the config files
+    if (!productBranch && product && product.repositories) {
+      productBranch = product.repositories.find(
+        item => item.project === release.product
+      );
+    }
 
     if (isXPI) {
       url = repoUrlBuilder(XPI_MANIFEST_REPO, release.revision);
-    } else if (productBranch) {
+    } else if (productBranch && productBranch.repo) {
       url = repoUrlBuilder(productBranch.repo, release.revision);
     }
 

--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -109,7 +109,7 @@ module.exports = {
         {
           prettyName: 'Staging fork',
           project: 'staging-android-components',
-          repo: 'https://github.com/mozilla-releng/staging-android-components/',
+          repo: 'https://github.com/mozilla-releng/staging-android-components',
           enableReleaseEta: false,
         },
       ],
@@ -119,6 +119,7 @@ module.exports = {
   XPI_MANIFEST: {
     branch: 'master',
     owner: 'mozilla-releng',
-    repo: 'staging-xpi-manifest',
+    project: 'staging-xpi-manifest',
+    repo: 'https://github.com/mozilla-releng/staging-xpi-manifest',
   },
 };

--- a/frontend/src/configs/development.js
+++ b/frontend/src/configs/development.js
@@ -100,7 +100,7 @@ module.exports = {
         {
           prettyName: 'Staging fork',
           project: 'staging-android-components',
-          repo: 'https://github.com/mozilla-releng/staging-android-components/',
+          repo: 'https://github.com/mozilla-releng/staging-android-components',
           enableReleaseEta: false,
         },
       ],
@@ -110,6 +110,7 @@ module.exports = {
   XPI_MANIFEST: {
     branch: 'master',
     owner: 'mozilla-releng',
-    repo: 'staging-xpi-manifest',
+    project: 'staging-xpi-manifest',
+    repo: 'https://github.com/mozilla-releng/staging-xpi-manifest',
   },
 };

--- a/frontend/src/configs/master.js
+++ b/frontend/src/configs/master.js
@@ -71,6 +71,7 @@ module.exports = {
   XPI_MANIFEST: {
     branch: 'master',
     owner: 'mozilla-releng',
-    repo: 'staging-xpi-manifest',
+    project: 'staging-xpi-manifest',
+    repo: 'https://github.com/mozilla-releng/staging-xpi-manifest',
   },
 };

--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -141,6 +141,7 @@ module.exports = {
   XPI_MANIFEST: {
     branch: 'master',
     owner: 'mozilla-extensions',
-    repo: 'xpi-manifest',
+    project: 'xpi-manifest',
+    repo: 'https://github.com/mozilla-extensions/xpi-manifest',
   },
 };

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -1,5 +1,3 @@
 export const USER_SESSION = 'react-auth0-session';
 export const CONTENT_MAX_WIDTH = 980;
 export const APP_BAR_HEIGHT = 64;
-export const XPI_MANIFEST_REPO =
-  'https://github.com/mozilla-extensions/xpi-manifest';

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -2,4 +2,4 @@ export const USER_SESSION = 'react-auth0-session';
 export const CONTENT_MAX_WIDTH = 980;
 export const APP_BAR_HEIGHT = 64;
 export const XPI_MANIFEST_REPO =
-  'https://github.com/mozilla-extensions/xpi-manifest/';
+  'https://github.com/mozilla-extensions/xpi-manifest';

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -1,3 +1,5 @@
 export const USER_SESSION = 'react-auth0-session';
 export const CONTENT_MAX_WIDTH = 980;
 export const APP_BAR_HEIGHT = 64;
+export const XPI_MANIFEST_REPO =
+  'https://github.com/mozilla-extensions/xpi-manifest/';

--- a/frontend/src/utils/helpers.js
+++ b/frontend/src/utils/helpers.js
@@ -1,0 +1,9 @@
+export const repoUrlBuilder = (urlPartial, revision) => {
+  if (urlPartial.includes('hg')) {
+    return `${urlPartial}/rev/${revision}`;
+  }
+
+  return `${urlPartial}/commit/${revision}`;
+};
+
+export default { repoUrlBuilder };

--- a/frontend/src/views/NewXPIRelease/index.jsx
+++ b/frontend/src/views/NewXPIRelease/index.jsx
@@ -61,15 +61,15 @@ export default function NewXPIRelease() {
       45
     )}`;
   const init = async () => {
-    const { owner, repo, branch } = config.XPI_MANIFEST;
-    const manifestCommit = await fetchManifestCommit(owner, repo, branch);
+    const { owner, project, branch } = config.XPI_MANIFEST;
+    const manifestCommit = await fetchManifestCommit(owner, project, branch);
     const { revision } = manifestCommit.data;
 
     setSelectedManifestCommit(revision);
     setSelectedXpi('');
     setSelectedXpiRevision('');
     setBuildNumber(0);
-    await fetchXpis(owner, repo, revision);
+    await fetchXpis(owner, project, revision);
   };
 
   useEffect(() => {
@@ -80,7 +80,7 @@ export default function NewXPIRelease() {
     setSelectedXpiRevision('');
     setSelectedXpi(xpi);
     setBuildNumber(0);
-    await fetchXpiCommits(xpi.owner, xpi.repo, xpi.branch);
+    await fetchXpiCommits(xpi.owner, xpi.project, xpi.branch);
   };
 
   const renderXpiSelect = () => {
@@ -135,7 +135,7 @@ export default function NewXPIRelease() {
     const version = (
       await fetchXpiVersion(
         selectedXpi.owner,
-        selectedXpi.repo,
+        selectedXpi.project,
         selectedXpi.revision,
         selectedXpi.directory
       )


### PR DESCRIPTION
As a follow-up to #426, I made the revision sha a link if the repo url exists (and can be found) per @wagnerand's request. 
![Screen Shot 2021-06-10 at 1 45 10 PM](https://user-images.githubusercontent.com/19615783/121597310-6397df00-c9f5-11eb-9e9d-0ad236f29fd2.png)

Since the repo url's aren't stored in the `Release` and `XPIRelease` tables, they can't be returned as part of the `release` API's response so I've opted for a solution that "just works". I figured this implementation would be revisited if/when we make changes to the hard coded repo's as part of the Releng for Moz shipit improvements.

I could add a test for this but I'm not seeing any UI test files, just a jest config file.