### PR TITLE
change use of project back to repo to match field in API response

### DIFF
--- a/frontend/src/views/NewXPIRelease/index.jsx
+++ b/frontend/src/views/NewXPIRelease/index.jsx
@@ -80,7 +80,7 @@ export default function NewXPIRelease() {
     setSelectedXpiRevision('');
     setSelectedXpi(xpi);
     setBuildNumber(0);
-    await fetchXpiCommits(xpi.owner, xpi.project, xpi.branch);
+    await fetchXpiCommits(xpi.owner, xpi.repo, xpi.branch);
   };
 
   const renderXpiSelect = () => {
@@ -132,10 +132,11 @@ export default function NewXPIRelease() {
 
   const handleXpiRevisionInputChange = async revision => {
     setSelectedXpiRevision(revision);
+
     const version = (
       await fetchXpiVersion(
         selectedXpi.owner,
-        selectedXpi.project,
+        selectedXpi.repo,
         selectedXpi.revision,
         selectedXpi.directory
       )


### PR DESCRIPTION
I updated the use of 'project' with 'repo' when I updated the config files in #777 and should've double-checked my assumptions. These changes broke part of the 'Create an XPI release' feature. My bad!

I verified this patch locally.