### PR TITLE
Notify additional people when releases change status

### DIFF
--- a/api/src/shipit_api/admin/api.py
+++ b/api/src/shipit_api/admin/api.py
@@ -138,7 +138,9 @@ def do_schedule_phase(session, phase, additional_shipit_emails=[]):
     extra_context = {"clientId": client_id}
 
     try:
-        result = hooks.triggerHook(hook["hook_group_id"], hook["hook_id"], rendered_hook_payload(phase, extra_context=extra_context, additional_shipit_emails=additional_shipit_emails))
+        result = hooks.triggerHook(
+            hook["hook_group_id"], hook["hook_id"], rendered_hook_payload(phase, extra_context=extra_context, additional_shipit_emails=additional_shipit_emails)
+        )
         phase.task_id = result["status"]["taskId"]
     except TaskclusterRestFailure as e:
         abort(400, str(e))

--- a/api/src/shipit_api/admin/api.py
+++ b/api/src/shipit_api/admin/api.py
@@ -124,7 +124,7 @@ def add_release(body):
     return release.json, 201
 
 
-def do_schedule_phase(session, phase):
+def do_schedule_phase(session, phase, additional_shipit_emails=[]):
     if phase.submitted:
         abort(409, "Already submitted!")
 
@@ -136,6 +136,9 @@ def do_schedule_phase(session, phase):
     hooks = get_service("hooks")
     client_id = hooks.options["credentials"]["clientId"].decode("utf-8")
     extra_context = {"clientId": client_id}
+    if len(additional_shipit_emails):
+        extra_context.update({ "additional_shipit_emails": additional_shipit_emails })
+
     try:
         result = hooks.triggerHook(hook["hook_group_id"], hook["hook_id"], rendered_hook_payload(phase, extra_context=extra_context))
         phase.task_id = result["status"]["taskId"]

--- a/api/src/shipit_api/admin/api.py
+++ b/api/src/shipit_api/admin/api.py
@@ -358,3 +358,14 @@ def _suggest_partials(product, branch, max_partials=3):
             "locales": get_locales(f"{HG_PREFIX}/{release['branch']}", release["revision"], product_to_appname(product)),
         }
     return suggested_partials
+
+
+def get_signoff_emails(phases):
+    additional_shipit_emails = set()
+    if phases:
+        for _phase in phases:
+            if _phase.completed_by is not None:
+                additional_shipit_emails.add(_phase.completed_by)
+            additional_shipit_emails.update({signoff.completed_by for signoff in _phase.signoffs if signoff.completed_by is not None})
+
+    return list(additional_shipit_emails)

--- a/api/src/shipit_api/admin/api.py
+++ b/api/src/shipit_api/admin/api.py
@@ -136,11 +136,9 @@ def do_schedule_phase(session, phase, additional_shipit_emails=[]):
     hooks = get_service("hooks")
     client_id = hooks.options["credentials"]["clientId"].decode("utf-8")
     extra_context = {"clientId": client_id}
-    if len(additional_shipit_emails):
-        extra_context.update({ "additional_shipit_emails": additional_shipit_emails })
 
     try:
-        result = hooks.triggerHook(hook["hook_group_id"], hook["hook_id"], rendered_hook_payload(phase, extra_context=extra_context))
+        result = hooks.triggerHook(hook["hook_group_id"], hook["hook_id"], rendered_hook_payload(phase, extra_context=extra_context, additional_shipit_emails=additional_shipit_emails))
         phase.task_id = result["status"]["taskId"]
     except TaskclusterRestFailure as e:
         abort(400, str(e))

--- a/api/src/shipit_api/admin/tasks.py
+++ b/api/src/shipit_api/admin/tasks.py
@@ -112,7 +112,7 @@ def render_action_hook(payload, context, delete_params=[]):
     return rendered_payload
 
 
-def rendered_hook_payload(phase, extra_context={}):
+def rendered_hook_payload(phase, extra_context={}, additional_shipit_emails=[]):
     context = phase.context_json
     previous_graph_ids = context["input"]["previous_graph_ids"]
     # The first ID is always the decision task ID. We need to update the
@@ -126,6 +126,8 @@ def rendered_hook_payload(phase, extra_context={}):
     # filter it out
     resolved_previous_graph_ids = filter(None, resolved_previous_graph_ids)
     context["input"]["previous_graph_ids"] = list(resolved_previous_graph_ids)
+    context["input"]["additional_shipit_emails"] = additional_shipit_emails
+
     if extra_context:
         context.update(extra_context)
     return render_action_hook(phase.task_json["hook_payload"], context)

--- a/api/src/shipit_api/admin/tasks.py
+++ b/api/src/shipit_api/admin/tasks.py
@@ -126,7 +126,9 @@ def rendered_hook_payload(phase, extra_context={}, additional_shipit_emails=[]):
     # filter it out
     resolved_previous_graph_ids = filter(None, resolved_previous_graph_ids)
     context["input"]["previous_graph_ids"] = list(resolved_previous_graph_ids)
-    context["input"]["additional_shipit_emails"] = additional_shipit_emails
+
+    if len(additional_shipit_emails):
+        context["input"]["additional_shipit_emails"] = additional_shipit_emails
 
     if extra_context:
         context.update(extra_context)

--- a/api/src/shipit_api/admin/xpi.py
+++ b/api/src/shipit_api/admin/xpi.py
@@ -9,7 +9,7 @@ from taskcluster.exceptions import TaskclusterRestFailure
 from werkzeug.exceptions import BadRequest
 
 from backend_common.taskcluster import get_root_url
-from shipit_api.admin.api import do_schedule_phase, notify_via_matrix
+from shipit_api.admin.api import do_schedule_phase, get_signoff_emails, notify_via_matrix
 from shipit_api.admin.github import get_xpi_type
 from shipit_api.admin.tasks import UnsupportedFlavor, generate_phases
 from shipit_api.common.config import SCOPE_PREFIX
@@ -80,23 +80,17 @@ def get_phase(name, phase):
 
 
 def schedule_phase(name, phase):
-    additional_shipit_emails = set()
-    phase_to_schedule = None
     session = current_app.db.session
     phases = session.query(XPIPhase).filter(XPIRelease.id == XPIPhase.release_id).filter(XPIRelease.name == name).all()
+    phase_to_schedule = list(filter(lambda _phase: _phase.name == phase, phases))
 
     # Get email for all signoffs from previous phases and phase scheduler
-    if phases:
-        for _phase in phases:
-            if _phase.name == phase:
-                phase_to_schedule = _phase
-            if _phase.completed_by is not None:
-                additional_shipit_emails.add(_phase.completed_by)
-            additional_shipit_emails.update({signoff.completed_by for signoff in _phase.signoffs if signoff.completed_by is not None})
+    additional_shipit_emails = get_signoff_emails(phases)
 
     if not phase_to_schedule:
         abort(404, f"phase {phase} not found")
 
+    phase_to_schedule = phase_to_schedule[0]
     # we must require scope which depends on XPI type
     xpi_type = _xpi_type(phase_to_schedule.release.revision, phase_to_schedule.release.xpi_name)
     required_permission = f"{SCOPE_PREFIX}/schedule_phase/xpi/{xpi_type}/{phase_to_schedule.name}"
@@ -104,8 +98,6 @@ def schedule_phase(name, phase):
         user_permissions = ", ".join(current_user.get_permissions())
         abort(401, f"required permission: {required_permission}, user permissions: {user_permissions}")
 
-    # remove duplicates
-    additional_shipit_emails = list(additional_shipit_emails)
     scheduled_phase = do_schedule_phase(session, phase_to_schedule, additional_shipit_emails)
     url = taskcluster_urls.ui(get_root_url(), f"/tasks/groups/{scheduled_phase.task_id}")
     logger.info("Phase %s of %s started by %s. - %s", scheduled_phase.name, scheduled_phase.release.name, scheduled_phase.completed_by, url)

--- a/api/src/shipit_api/admin/xpi.py
+++ b/api/src/shipit_api/admin/xpi.py
@@ -84,15 +84,15 @@ def schedule_phase(name, phase):
     phase_to_schedule = None
     session = current_app.db.session
     phases = session.query(XPIPhase).filter(XPIRelease.id == XPIPhase.release_id).filter(XPIRelease.name == name).all()
-    
+
     # Get email for all signoffs from previous phases and phase scheduler
     if len(phases):
         for _phase in phases:
             if _phase.name == phase:
                 phase_to_schedule = _phase
-            if _phase.completed_by != None:
+            if _phase.completed_by is not None:
                 additional_shipit_emails.append(_phase.completed_by)
-            additional_shipit_emails = additional_shipit_emails + [signoff.completed_by for signoff in _phase.signoffs if signoff.completed_by != None]
+            additional_shipit_emails = additional_shipit_emails + [signoff.completed_by for signoff in _phase.signoffs if signoff.completed_by is not None]
 
     if not phase_to_schedule:
         abort(404, f"phase {phase} not found")
@@ -103,7 +103,7 @@ def schedule_phase(name, phase):
     if not current_user.has_permissions(required_permission):
         user_permissions = ", ".join(current_user.get_permissions())
         abort(401, f"required permission: {required_permission}, user permissions: {user_permissions}")
-    
+
     # remove duplicates
     additional_shipit_emails = list(set(additional_shipit_emails))
     scheduled_phase = do_schedule_phase(session, phase_to_schedule, additional_shipit_emails)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -8,6 +8,7 @@ import os
 import pytest
 
 import backend_common
+from shipit_api.common.models import XPI, XPIRelease
 
 
 @pytest.fixture(scope="session")
@@ -33,3 +34,22 @@ def app():
     with app.app_context():
         backend_common.testing.configure_app(app)
         yield app
+
+
+def mock_generate_phases(release):
+    phases = []
+    for phase in ["build", "promote", "ship"]:
+        phase_obj = release.phase_class(name=phase, task_id="", task={}, context={}, completed_by=None)
+        phase_obj.signoffs = release.phase_signoffs(phase)
+        phases.append(phase_obj)
+    return phases
+
+
+@pytest.fixture
+def test_xpi_release():
+    xpi = XPI(name="staging-public", revision="2c91fa1f75a1e0ff8b16055b944fe1d2fe10175", version="1.0.0")
+    release = XPIRelease(
+        build_number=5, revision="be8a48ca7a82c79cefc8ac10dee182005cdbd3c7", status="scheduled", xpi_type="addon-type", project="staging-xpi-manifest", xpi=xpi
+    )
+    release.phases = mock_generate_phases(release)
+    return release


### PR DESCRIPTION
Resolves #439. I've tested this locally with my [xpi-manifest pr](https://github.com/mozilla-extensions/xpi-manifest/pull/120) pushed to staging-xpi-manifest and after creating an xpi release against staging-public, I saw emails (started and on completion) when a release was promoted to the next stage. However, since I was the scheduler and sign-off person for my tests, its an incomplete test so we'll want to do more of it on staging. 

Ben, it'd be good to have some tests for this. Where would you prefer I add them?