### PR TITLE
Turn partner builds on earlier in the beta cycle

### DIFF
--- a/api/src/shipit_api/admin/release.py
+++ b/api/src/shipit_api/admin/release.py
@@ -97,7 +97,7 @@ def is_partner_enabled(product, version, min_version=60):
     if product == "firefox":
         firefox_version = FirefoxVersion.parse(version)
         return firefox_version.major_number >= min_version and any(
-            (firefox_version.is_beta and firefox_version.beta_number >= 8, firefox_version.is_release, firefox_version.is_esr)
+            (firefox_version.is_beta and firefox_version.beta_number >= 5, firefox_version.is_release, firefox_version.is_esr)
         )
 
     return False


### PR DESCRIPTION
This was already done in #443, but then reverted by mistake in #537.