### PR TITLE
product-details fixes

### DIFF
--- a/api/src/shipit_api/admin/product_details.py
+++ b/api/src/shipit_api/admin/product_details.py
@@ -1005,16 +1005,13 @@ async def rebuild(
         run_check(["git", "clean", "-xfd"], cwd=shipit_api.common.config.PRODUCT_DETAILS_DIR, secrets=secrets)
     else:
         run_check(
-            ["git", "clone", git_repo_url, shipit_api.common.config.PRODUCT_DETAILS_DIR.name],
+            ["git", "clone", "-b", git_branch, git_repo_url, shipit_api.common.config.PRODUCT_DETAILS_DIR.name],
             cwd=shipit_api.common.config.PRODUCT_DETAILS_DIR.parent,
             secrets=secrets,
         )
         run_check(["git", "config", "http.postBuffer", "12M"], cwd=shipit_api.common.config.PRODUCT_DETAILS_DIR, secrets=secrets)
         run_check(["git", "config", "user.email", "release-services+robot@mozilla.com"], cwd=shipit_api.common.config.PRODUCT_DETAILS_DIR, secrets=secrets)
         run_check(["git", "config", "user.name", "Release Services Robot"], cwd=shipit_api.common.config.PRODUCT_DETAILS_DIR, secrets=secrets)
-        # Checkout the branch we are working on
-        logger.info(f"Checkout {git_branch} branch.")
-        run_check(["git", "checkout", "-b", git_branch, f"origin/{git_branch}"], cwd=shipit_api.common.config.PRODUCT_DETAILS_DIR, secrets=secrets)
 
     # XXX: we need to implement how to figure out breakpoint_version from old_product_details
     # if breakpoint_version is not provided we should figure it out from old_product_details


### PR DESCRIPTION
This fixes a couple of issues with product-details updates:
- in local development mode, the git checkout would just fail
- avoid crashing if a file doesn't exist yet, e.g. when pinebuild.json was added in #893, we ran into https://github.com/mozilla-releng/shipit/issues/907#issuecomment-937947975