### PR TITLE
cli: add "dev" to the list of legit product-details branches

### DIFF
--- a/api/src/shipit_api/admin/cli.py
+++ b/api/src/shipit_api/admin/cli.py
@@ -88,7 +88,7 @@ async def download_product_details(url: str, download_dir: str):
 @click.option("--folder-in-repo", type=str, required=True, default="public/")
 @click.option(
     "--channel",
-    type=click.Choice(["development", "main", "testing", "staging", "production"]),
+    type=click.Choice(["development", "main", "testing", "dev", "staging", "production"]),
     required=True,
     default=os.environ.get("DEPLOYMENT_BRANCH", "main"),
 )


### PR DESCRIPTION
shipit staging uses that branch, this makes it easier to replicate locally.