### PR TITLE
Change config to ignore non-security dot releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,16 @@ updates:
 - package-ecosystem: pip
   directory: "/api/requirements"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 50
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-patch"]
 - package-ecosystem: npm
   directory: "/frontend"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 50
+  ignore:
+    - dependency-name: "*"
+      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
I did the same thing for Balrog and will hopefully make these updates a bit more manageable.