### PR TITLE
fix malformed XPIRelease openapi schema

### DIFF
--- a/api/src/shipit_api/admin/api.yml
+++ b/api/src/shipit_api/admin/api.yml
@@ -957,18 +957,16 @@ components:
         build_number:
           type: integer
     XPIRelease:
-      # TODO: fixme
       type: object
       required:
-      - xpi_name
-      - xpi_revision
-      - xpi_version
-      - build_number
-      - name
-      - phases
-      - status
-      - revision
-      type: object
+        - xpi_name
+        - xpi_revision
+        - xpi_version
+        - build_number
+        - name
+        - phases
+        - status
+        - revision
       properties:
         name:
           type: string


### PR DESCRIPTION
fix malformed XPIRelease openapi schema in api/src/shipit_api/admin/api.yml