### PR TITLE
frontend: don't filter releases based on branch when guessing build number

### DIFF
--- a/frontend/src/components/api.js
+++ b/frontend/src/components/api.js
@@ -10,9 +10,9 @@ import config from '../config';
  * This will fetch all release builds including shipped, aborted, and not
  * started yet.
  */
-export async function getBuildNumbers(product, branch, version) {
+export async function getBuildNumbers(product, version) {
   const res = await axios.get('/releases', {
-    params: { product, branch, version, status: 'shipped,aborted,scheduled' },
+    params: { product, version, status: 'shipped,aborted,scheduled' },
     usePublicApi: true,
   });
   const releases = res.data;
@@ -89,8 +89,8 @@ export async function getRecentXPIReleases(limit = 4) {
   return releases.slice(0, limit);
 }
 
-export async function guessBuildNumber(product, branch, version) {
-  const buildNumbers = await getBuildNumbers(product, branch, version);
+export async function guessBuildNumber(product, version) {
+  const buildNumbers = await getBuildNumbers(product, version);
   const nextBuildNumber =
     buildNumbers.length !== 0 ? Math.max(...buildNumbers) + 1 : 1;
 

--- a/frontend/src/views/NewRelease/index.jsx
+++ b/frontend/src/views/NewRelease/index.jsx
@@ -132,11 +132,7 @@ export default function NewRelease() {
       )
     ).data;
     const nextBuildNumber = (
-      await guessBuildNumberAction(
-        selectedProduct.product,
-        selectedBranch.branch,
-        ver
-      )
+      await guessBuildNumberAction(selectedProduct.product, ver)
     ).data;
 
     setVersion(ver);


### PR DESCRIPTION
The release name, i.e. (product, version, build_number) tuple, must be
unique, so if we filter on branch we can fail at submit time with a
constraint violation.

This shouldn't matter on prod because the version/branch mapping is
unambiguous but on staging this can happen (different github repo
branches, or hg project repos).