### PR TITLE
reenable normandy-privileged

### DIFF
--- a/api/src/shipit_api/admin/settings.py
+++ b/api/src/shipit_api/admin/settings.py
@@ -88,6 +88,7 @@ LDAP_GROUPS = {
     "xpi_system_signoff": XPI_SYSTEM_ADMIN_LDAP_GROUP + ADMIN_LDAP_GROUP,
     "xpi_mozillaonline-privileged_signoff": XPI_MOZILLAONLINE_PRIVILEGED_LDAP_GROUP + ADMIN_LDAP_GROUP,
     "xpi_mozillaonline-privileged_admin_signoff": XPI_MOZILLAONLINE_PRIVILEGED_ADMIN_LDAP_GROUP + ADMIN_LDAP_GROUP,
+    "xpi_normandy-privileged_signoff": ADMIN_LDAP_GROUP,
 }
 
 AUTH0_AUTH_SCOPES = dict()
@@ -144,6 +145,7 @@ AUTH0_AUTH_SCOPES.update(
                 + LDAP_GROUPS["xpi_system_signoff"]
                 + LDAP_GROUPS["xpi_mozillaonline-privileged_signoff"]
                 + LDAP_GROUPS["xpi_mozillaonline-privileged_admin_signoff"]
+                + LDAP_GROUPS["xpi_normandy-privileged_signoff"]
                 + LDAP_GROUPS["focus-android-signoff"]
             )
         )
@@ -151,7 +153,7 @@ AUTH0_AUTH_SCOPES.update(
 )
 
 # XPI scopes
-for xpi_type in ["privileged", "system", "mozillaonline-privileged"]:
+for xpi_type in ["privileged", "system", "mozillaonline-privileged", "normandy-privileged"]:
     # "build", "signoff", and "admin_signoff" groups can create and cancel releases
     AUTH0_AUTH_SCOPES.update(
         {

--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -530,5 +530,13 @@ SIGNOFFS = {
                 },
             ],
         },
+        "normandy-privileged": {
+            "promote": [
+                {"name": "Normandy privileged admin", "description": "Promote XPI", "permissions": "xpi_normandy-privileged_signoff"},
+            ],
+            "ship": [
+                {"name": "Normandy privileged admin", "description": "Ship XPI", "permissions": "xpi_normandy-privileged_signoff"},
+            ],
+        },
     },
 }


### PR DESCRIPTION
Largely reverts #859, but leaves out the nonexistent?
`xpi_normandy_admin` ldap group.

We have two problems: first, we had abandoned normandy-privileged
releases in-flight in production shipit, and after landing #859 we no
longer had scopes to either move forward or cancel those releases
without either reverting or reaching into the DB.

Second, we have an unexpected normandy-privileged release coming, and
there's [pushback](https://github.com/mozilla-extensions/xpi-manifest/pull/149#discussion_r801858020) against using the `privileged` format for this,
even if they both use the exact same signing format behind the scenes.

Let's reenable `normandy-privileged` and leave it enabled until it's
clear we will definitely not ship any more normandy-privileged addons.