### PR TITLE
bump tox from 3.24.4 to 3.25.0

### DIFF
--- a/api/requirements/local.txt
+++ b/api/requirements/local.txt
@@ -6,7 +6,7 @@
 #    pip-compile-multi
 #
 -r test.txt
-backports.entry-points-selectable==1.1.1 \
+backports-entry-points-selectable==1.1.1 \
     --hash=sha256:7fceed9532a7aa2bd888654a7314f864a3c16a4e710b34a58cfc0f08114c663b \
     --hash=sha256:914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386
     # via virtualenv
@@ -20,9 +20,9 @@ filelock==3.4.0 \
     # via
     #   tox
     #   virtualenv
-tox==3.24.4 \
-    --hash=sha256:5e274227a53dc9ef856767c21867377ba395992549f02ce55eb549f9fb9a8d10 \
-    --hash=sha256:c30b57fa2477f1fb7c36aa1d83292d5c2336cd0018119e1b1c17340e2c2708ca
+tox==3.25.0 \
+    --hash=sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a \
+    --hash=sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160
     # via -r requirements/local.in
 virtualenv==20.10.0 \
     --hash=sha256:4b02e52a624336eece99c96e3ab7111f469c24ba226a53ec474e8e787b365814 \

--- a/api/requirements/tox.txt
+++ b/api/requirements/tox.txt
@@ -5,7 +5,7 @@
 #
 #    pip-compile-multi
 #
-backports.entry-points-selectable==1.1.1 \
+backports-entry-points-selectable==1.1.1 \
     --hash=sha256:7fceed9532a7aa2bd888654a7314f864a3c16a4e710b34a58cfc0f08114c663b \
     --hash=sha256:914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386
     # via virtualenv
@@ -49,9 +49,9 @@ toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
     # via tox
-tox==3.24.4 \
-    --hash=sha256:5e274227a53dc9ef856767c21867377ba395992549f02ce55eb549f9fb9a8d10 \
-    --hash=sha256:c30b57fa2477f1fb7c36aa1d83292d5c2336cd0018119e1b1c17340e2c2708ca
+tox==3.25.0 \
+    --hash=sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a \
+    --hash=sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160
     # via -r requirements/tox.in
 virtualenv==20.10.0 \
     --hash=sha256:4b02e52a624336eece99c96e3ab7111f469c24ba226a53ec474e8e787b365814 \


### PR DESCRIPTION
dependabot generated a confusing patch for this - I don't know why - so I generated this myself with pip-compile-multi.