### PR TITLE
Mark phase as completed when the task graph has completed

### DIFF
--- a/frontend/src/components/PhaseProgress/index.jsx
+++ b/frontend/src/components/PhaseProgress/index.jsx
@@ -177,7 +177,8 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
       (idx === 0 || // The first phase can be scheduled anytime
       allowPhaseSkipping || // Can schedule anything
       phases[idx - 1].tcStatus === 'completed' || // previsous phase is done
-        // Block XPI releases if there are failed tasks in the Phase's task group
+        // Block XPI (aka add-on) Phases if there are 
+        // failed tasks in the previous Phase's task group
         (phases[idx - 1].tcStatus === 'warning' && !('xpi_name' in release)) ||
         // Special case for Firefox RC.
         // push_firefox can be scheduled even if ship_firefox_rc (the previous

--- a/frontend/src/components/PhaseProgress/index.jsx
+++ b/frontend/src/components/PhaseProgress/index.jsx
@@ -177,7 +177,7 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
       (idx === 0 || // The first phase can be scheduled anytime
       allowPhaseSkipping || // Can schedule anything
       phases[idx - 1].tcStatus === 'completed' || // previsous phase is done
-        // Block XPI (aka add-on) Phases if there are 
+        // Block XPI (aka add-on) Phases if there are
         // failed tasks in the previous Phase's task group
         (phases[idx - 1].tcStatus === 'warning' && !('xpi_name' in release)) ||
         // Special case for Firefox RC.

--- a/frontend/src/components/PhaseProgress/index.jsx
+++ b/frontend/src/components/PhaseProgress/index.jsx
@@ -177,7 +177,8 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
       (idx === 0 || // The first phase can be scheduled anytime
       allowPhaseSkipping || // Can schedule anything
       phases[idx - 1].tcStatus === 'completed' || // previsous phase is done
-        phases[idx - 1].tcStatus === 'warning' ||
+        // Block XPI releases if there are failed tasks in the Phase's task group
+        (phases[idx - 1].tcStatus === 'warning' && !('xpi_name' in release)) ||
         // Special case for Firefox RC.
         // push_firefox can be scheduled even if ship_firefox_rc (the previous
         // phase) is not ready. We still need to be sure that

--- a/frontend/src/components/PhaseProgress/index.jsx
+++ b/frontend/src/components/PhaseProgress/index.jsx
@@ -98,7 +98,7 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
 
     if (phase.submitted) {
       const submittedTaskStatuses = ['unscheduled', 'pending', 'running'];
-      const errorStatuses = ['failed', 'exception'];
+      const errorStatuses = ['failed', 'exception', 'warning'];
       const inProgress = submittedTaskStatuses.includes(phase.tcStatus);
       const taskError = errorStatuses.includes(phase.tcStatus);
 
@@ -177,6 +177,7 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
       (idx === 0 || // The first phase can be scheduled anytime
       allowPhaseSkipping || // Can schedule anything
       phases[idx - 1].tcStatus === 'completed' || // previsous phase is done
+        phases[idx - 1].tcStatus === 'warning' ||
         // Special case for Firefox RC.
         // push_firefox can be scheduled even if ship_firefox_rc (the previous
         // phase) is not ready. We still need to be sure that

--- a/frontend/src/components/api.js
+++ b/frontend/src/components/api.js
@@ -366,7 +366,7 @@ export async function getPendingReleases(
           );
 
           if (phase.submitted && phase.actionTaskId) {
-            const tcStatus = getTcStatus(phase);
+            const tcStatus = await getTcStatus(phase);
 
             if (tcStatus) {
               // Only update the TC status for not expired tasks

--- a/frontend/src/components/api.js
+++ b/frontend/src/components/api.js
@@ -324,7 +324,7 @@ async function getTcStatus(phase) {
 
       // If there are errors the phase failed
       if (statuses.some(status => isError.includes(status))) {
-        return 'failed';
+        return 'warning';
       }
 
       // If there are no errors but


### PR DESCRIPTION
Modifies the ShipIt front-end to display the Phase state taking into account the state of the tasks in the graph's group.