### PR TITLE
Update local node version to 16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
 
   ui:
     # SSL doesn't work with node:current
-    image: node:10
+    image: node:16
     ports:
       - "8010:8010"
     volumes:


### PR DESCRIPTION
Fixes
```
shipit-ui-1 | error is-absolute-url@4.0.1: The engine "node" is incompatible with this module. Expected version "^12.20.0 || ^14.13.1 || >=16.0.0". Got "10.24.1
```