### PR TITLE
Bump Nightly version and release dates

### DIFF
--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -46,17 +46,17 @@ ESR_BRANCH_PREFIX = "releases/mozilla-esr"
 # day).
 # We could have used the in-tree version, but there can be race conditions,
 # e.g. version bumped, but still no builds available.
-FIREFOX_NIGHTLY = "103.0a1"
+FIREFOX_NIGHTLY = "104.0a1"
 
 # The next 6 dates are information about the current and next release
 # They must be updated at the same time as FIREFOX_NIGHTLY
 # They can be found: https://wiki.mozilla.org/Release_Management/Calendar
-LAST_SOFTFREEZE_DATE = "2022-05-26"
-LAST_MERGE_DATE = "2022-05-30"
-LAST_RELEASE_DATE = "2022-05-31"
-NEXT_SOFTFREEZE_DATE = "2022-06-23"
-NEXT_MERGE_DATE = "2022-06-27"
-NEXT_RELEASE_DATE = "2022-06-28"
+LAST_SOFTFREEZE_DATE = "2022-06-23"
+LAST_MERGE_DATE = "2022-06-27"
+LAST_RELEASE_DATE = "2022-06-28"
+NEXT_SOFTFREEZE_DATE = "2022-07-21"
+NEXT_MERGE_DATE = "2022-07-25"
+NEXT_RELEASE_DATE = "2022-07-26"
 
 # Fennec Nightly users have been migrated to Fenix, thus we don't need to bump
 # the following numbers anymore.


### PR DESCRIPTION
Bump FIREFOX_NIGHTLY to 104 and updates LAST/NEXT dates.