### PR TITLE
Revert change to THUNDERBIRD_RELEASE_BRANCH that broke thunderbird.net.

### DIFF
--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -74,7 +74,7 @@ IOS_VERSION = "14.1"
 LATEST_THUNDERBIRD_ALPHA_VERSION = "54.0a2"
 LATEST_THUNDERBIRD_NIGHTLY_VERSION = "103.0a1"
 # TODO: Need to update this every cycle
-THUNDERBIRD_RELEASE_BRANCH = "releases/comm-esr102"
+THUNDERBIRD_RELEASE_BRANCH = "releases/comm-esr91"
 THUNDERBIRD_BETA_BRANCH = "releases/comm-beta"
 
 # Mixed


### PR DESCRIPTION
This is somewhat urgent as thunderbird.net doesn't update with the current state of product-details.