### PR TITLE
Allow connections to local db container on localhost:5432

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,8 @@ services:
 
   db:
     image: postgres:11
+    ports:
+      - "5432:5432"
     volumes:
       - dbstore:/var/lib/postgresql/data
       - ./api/docker.d/postgres_create_readonly_user.sh:/docker-entrypoint-initdb.d/postgres_create_readonly_user.sh


### PR DESCRIPTION
I find connecting to the local ShipIt db container useful. Landing this patch so I don't have to keep adding this when I clean my ShipIt checkout.