### PR TITLE
Bug 1778290 - Disable phase schedule/signoff button once clicked

### DIFF
--- a/frontend/src/components/Button/index.jsx
+++ b/frontend/src/components/Button/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { oneOf } from 'prop-types';
 import { ThemeProvider } from '@material-ui/styles';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 import MuiButton from '@material-ui/core/Button';
 import { red } from '@material-ui/core/colors';
 
-const dangerTheme = createMuiTheme({
+const dangerTheme = createTheme({
   palette: {
     primary: red,
   },

--- a/frontend/src/components/PhaseProgress/index.jsx
+++ b/frontend/src/components/PhaseProgress/index.jsx
@@ -37,6 +37,9 @@ const useStyles = makeStyles({
 export default function PhaseProgress({ release, readOnly, xpi }) {
   const classes = useStyles();
   const { fetchReleases } = useContext(ReleaseContext);
+  const [disableScheduleOrSignoff, setDisableScheduleOrSignoff] = useState(
+    false
+  );
   const [open, setOpen] = useState(false);
   const [phase, setPhase] = useState({});
   const [selectedSignoffUID, setSelectedSignoffUID] = useState(null);
@@ -61,6 +64,8 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
   };
 
   const scheduleOrSignoff = async () => {
+    setDisableScheduleOrSignoff(true);
+
     if (phase.signoffs && phase.signoffs.length > 0) {
       const result = await phaseSignOffAction(
         release.name,
@@ -269,6 +274,7 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
             Close
           </Button>
           <Button
+            disabled={disableScheduleOrSignoff}
             onClick={() => scheduleOrSignoff(release.name, phase.name)}
             variant="contained"
             color="primary">

--- a/frontend/src/components/PhaseProgress/index.jsx
+++ b/frontend/src/components/PhaseProgress/index.jsx
@@ -73,7 +73,9 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
         selectedSignoffUID,
         xpi ? '/xpi/signoff' : '/signoff'
       );
+
       setDisableScheduleOrSignoff(false);
+
       if (!result.error) {
         handleClose({ refresh: true });
       }
@@ -83,7 +85,9 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
         phase.name,
         xpi ? '/xpi/releases' : '/releases'
       );
+
       setDisableScheduleOrSignoff(false);
+
       if (!result.error) {
         handleClose({ refresh: true });
       }

--- a/frontend/src/components/PhaseProgress/index.jsx
+++ b/frontend/src/components/PhaseProgress/index.jsx
@@ -73,7 +73,7 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
         selectedSignoffUID,
         xpi ? '/xpi/signoff' : '/signoff'
       );
-
+      setDisableScheduleOrSignoff(false);
       if (!result.error) {
         handleClose({ refresh: true });
       }
@@ -83,7 +83,7 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
         phase.name,
         xpi ? '/xpi/releases' : '/releases'
       );
-
+      setDisableScheduleOrSignoff(false);
       if (!result.error) {
         handleClose({ refresh: true });
       }

--- a/frontend/src/theme.js
+++ b/frontend/src/theme.js
@@ -1,6 +1,6 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-export default createMuiTheme({
+export default createTheme({
   overrides: {
     MuiList: {
       padding: {


### PR DESCRIPTION
Mitigates double-scheduling of phases by double-clicking on the "schedule" in the "Schedule Phase" modal.