### PR TITLE
Bug 1778290 - prevent a phase getting scheduled more than once

### DIFF
--- a/api/src/shipit_api/admin/api.py
+++ b/api/src/shipit_api/admin/api.py
@@ -169,7 +169,9 @@ def do_schedule_phase(session, phase, additional_shipit_emails=()):
 
 def schedule_phase(name, phase):
     session = current_app.db.session
-    phase = session.query(Phase).filter(Release.id == Phase.release_id).filter(Release.name == name).filter(Phase.name == phase).first_or_404()
+    phase = (
+        session.query(Phase).with_for_update().filter(Release.id == Phase.release_id).filter(Release.name == name).filter(Phase.name == phase).first_or_404()
+    )
 
     # we must require scope which depends on product
     required_permission = f"{SCOPE_PREFIX}/schedule_phase/{phase.release.product}/{phase.name}"


### PR DESCRIPTION
If we get 2 requests to schedule a phase around the same time, there's a
race between the first request marking the phase as submitted and the
second one checking the status before it calls out to TC.

So take a db lock on the relevant phase before we schedule it.

~TODO: test locally and add an automated test~