### PR TITLE
Bug 1777255 - Bump mozilla-version to 1.1.0

### DIFF
--- a/api/requirements/public.txt
+++ b/api/requirements/public.txt
@@ -243,9 +243,9 @@ markupsafe==2.0.1 \
     # via
     #   jinja2
     #   mako
-mozilla-version==1.0.1 \
-    --hash=sha256:9d6f50eb0b362106e468ba84cafd683d56cab153e252c2d272b135b5c65da48e \
-    --hash=sha256:eb913cc47fd244e8767d19eb53c68875ea77740eaf1ca518213c3e4b6b2f050b
+mozilla-version==1.1.0 \
+    --hash=sha256:1a56c1ea668ec10e18c0a2e394a79373b5ec0ea25a33d204ac6382f337cb9f8a \
+    --hash=sha256:1fdd9ed90eeec801852b981e98d5b4f6a69efee32eb5f492db86be97393ce4e9
     # via -r requirements/public.in
 openapi-schema-validator==0.1.5 \
     --hash=sha256:215b516d0942f4e8e2446cf3f7d4ff2ed71d102ebddcc30526d8a3f706ab1df6 \


### PR DESCRIPTION
Tested in staging:

![image](https://user-images.githubusercontent.com/5907366/177964146-fdf56000-c713-4966-b8e9-9592626cdda0.png)


(Note the version number is not `104.0-beta.1` anymore). 

Shipit manage to generate both the `promote`[1] and the `ship`[2] graphs. Errors in the ship graph are on the scriptworker side. I'm working on them. 

[1] https://firefox-ci-tc.services.mozilla.com/tasks/groups/X7VCYIwnSY6Afvg9DFTTJQ
[2] https://firefox-ci-tc.services.mozilla.com/tasks/groups/GPtOmmq5Rk6P0qnN-AG7KQ