### PR TITLE
Bug 1786780 - Add firefox-android monorepo

### DIFF
--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -480,7 +480,16 @@ SUPPORTED_FLAVORS = {
     ],
 }
 
-SUPPORTED_MOBILE_REPO_NAMES = ("fenix", "android-components", "staging-fenix", "staging-android-components", "focus-android", "staging-focus-android")
+SUPPORTED_MOBILE_REPO_NAMES = (
+    "android-components",  # TODO bug 1797700, remove android-components
+    "fenix",
+    "firefox-android",
+    "focus-android",
+    "staging-android-components",
+    "staging-fenix",
+    "staging-firefox-android",
+    "staging-focus-android",
+)
 
 XPI_LAX_SIGN_OFF = config("XPI_LAX_SIGN_OFF", default=False, cast=bool)
 SIGNOFFS = {

--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -108,9 +108,16 @@ module.exports = {
       ],
       repositories: [
         {
-          prettyName: 'Staging fork',
+          // TODO bug 1797700, remove the staging-android-components repo
+          prettyName: 'Deprecated fork',
           project: 'staging-android-components',
           repo: 'https://github.com/mozilla-releng/staging-android-components',
+          enableReleaseEta: false,
+        },
+        {
+          prettyName: 'Staging Android monorepo',
+          project: 'staging-firefox-android',
+          repo: 'https://github.com/mozilla-releng/staging-firefox-android',
           enableReleaseEta: false,
         },
       ],

--- a/frontend/src/configs/development.js
+++ b/frontend/src/configs/development.js
@@ -106,9 +106,16 @@ module.exports = {
       ],
       repositories: [
         {
-          prettyName: 'Staging fork',
+          // TODO bug 1797700, remove the staging-android-components repo
+          prettyName: 'Deprecated fork',
           project: 'staging-android-components',
           repo: 'https://github.com/mozilla-releng/staging-android-components',
+          enableReleaseEta: false,
+        },
+        {
+          prettyName: 'Staging Android monorepo',
+          project: 'staging-firefox-android',
+          repo: 'https://github.com/mozilla-releng/staging-firefox-android',
           enableReleaseEta: false,
         },
       ],

--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -133,9 +133,16 @@ module.exports = {
       ],
       repositories: [
         {
-          prettyName: 'Official repo',
+          // TODO bug 1797700, remove the android-components repo
+          prettyName: 'Deprecated repo',
           project: 'android-components',
           repo: 'https://github.com/mozilla-mobile/android-components',
+          enableReleaseEta: false,
+        },
+        {
+          prettyName: 'Android monorepo',
+          project: 'firefox-android',
+          repo: 'https://github.com/mozilla-mobile/firefox-android',
           enableReleaseEta: false,
         },
       ],


### PR DESCRIPTION
This needs to be deployed to production on Monday, October 31st. 