### PR TITLE
Don't show an error on a phase if it is not blocking the following phase

### DIFF
--- a/frontend/src/components/api.js
+++ b/frontend/src/components/api.js
@@ -349,6 +349,18 @@ async function getPhaseSignOffs(releaseName, phaseName, url = '/signoff') {
   return req.data.signoffs;
 }
 
+async function getStatus(release, phase) {
+  const isXPIRelease = 'xpi_name' in release;
+
+  if (isXPIRelease) {
+    return getTcStatus(phase);
+  }
+
+  const status = await getTaskStatus(phase.actionTaskId);
+
+  return status.status.state;
+}
+
 export async function getPendingReleases(
   url = '/releases',
   signoffUrl = '/signoff',
@@ -366,7 +378,7 @@ export async function getPendingReleases(
           );
 
           if (phase.submitted && phase.actionTaskId) {
-            const tcStatus = await getTcStatus(phase);
+            const tcStatus = await getStatus(release, phase);
 
             if (tcStatus) {
               // Only update the TC status for not expired tasks


### PR DESCRIPTION
The red triangle of doom 🔺 implies that a phase failed and its blocking the scheduling of the next phase. For Firefox, phases with failed tasks are non-blocking.