### PR TITLE
Bug 1802483 - try not to break the UI when pending releases have expired tasks

### DIFF
--- a/frontend/src/components/api.js
+++ b/frontend/src/components/api.js
@@ -358,6 +358,10 @@ async function getStatus(release, phase) {
 
   const status = await getTaskStatus(phase.actionTaskId);
 
+  if (!status) {
+    return null; // expired?
+  }
+
   return status.status.state;
 }
 


### PR DESCRIPTION
This happens easily on staging because try tasks expire quickly, and releases can stay unshipped for extended periods.