### PR TITLE
Bug 1808607 - Ship Fenix off of the firefox-android repo

### DIFF
--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -80,7 +80,7 @@ module.exports = {
     },
     {
       product: 'fenix',
-      prettyName: 'Fenix',
+      prettyName: 'Deprecated Fenix',
       appName: 'fenix',
       branches: [
         {
@@ -99,7 +99,7 @@ module.exports = {
     },
     {
       product: 'firefox-android',
-      prettyName: 'Firefox Android (Android-Components, Focus)',
+      prettyName: 'Firefox Android (Android-Components, Fenix, Focus)',
       appName: 'firefox-android',
       branches: [
         {

--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -98,25 +98,6 @@ module.exports = {
       enablePartials: false,
     },
     {
-      product: 'android-components',
-      prettyName: 'Deprecated Android-Components',
-      appName: 'android-components',
-      branches: [
-        {
-          branch: '',
-        },
-      ],
-      repositories: [
-        {
-          prettyName: 'Staging Android monorepo',
-          project: 'staging-firefox-android',
-          repo: 'https://github.com/mozilla-releng/staging-firefox-android',
-          enableReleaseEta: false,
-        },
-      ],
-      enablePartials: false,
-    },
-    {
       product: 'firefox-android',
       prettyName: 'Firefox Android (Android-Components, Focus)',
       appName: 'firefox-android',
@@ -130,25 +111,6 @@ module.exports = {
           prettyName: 'Staging Android monorepo',
           project: 'staging-firefox-android',
           repo: 'https://github.com/mozilla-releng/staging-firefox-android',
-          enableReleaseEta: false,
-        },
-      ],
-      enablePartials: false,
-    },
-    {
-      product: 'focus-android',
-      prettyName: 'Deprecated Focus for Android',
-      appName: 'focus-android',
-      branches: [
-        {
-          branch: '',
-        },
-      ],
-      repositories: [
-        {
-          prettyName: 'Staging fork',
-          project: 'staging-focus-android',
-          repo: 'https://github.com/mozilla-releng/staging-focus-android',
           enableReleaseEta: false,
         },
       ],

--- a/frontend/src/configs/development.js
+++ b/frontend/src/configs/development.js
@@ -96,25 +96,6 @@ module.exports = {
       enablePartials: false,
     },
     {
-      product: 'android-components',
-      prettyName: 'Deprecated Android-Components',
-      appName: 'android-components',
-      branches: [
-        {
-          branch: '',
-        },
-      ],
-      repositories: [
-        {
-          prettyName: 'Staging Android monorepo',
-          project: 'staging-firefox-android',
-          repo: 'https://github.com/mozilla-releng/staging-firefox-android',
-          enableReleaseEta: false,
-        },
-      ],
-      enablePartials: false,
-    },
-    {
       product: 'firefox-android',
       prettyName: 'Firefox Android (Android-Components, Focus)',
       appName: 'firefox-android',
@@ -128,25 +109,6 @@ module.exports = {
           prettyName: 'Staging Android monorepo',
           project: 'staging-firefox-android',
           repo: 'https://github.com/mozilla-releng/staging-firefox-android',
-          enableReleaseEta: false,
-        },
-      ],
-      enablePartials: false,
-    },
-    {
-      product: 'focus-android',
-      prettyName: 'Deprecated Focus for Android',
-      appName: 'focus-android',
-      branches: [
-        {
-          branch: '',
-        },
-      ],
-      repositories: [
-        {
-          prettyName: 'Staging fork',
-          project: 'staging-focus-android',
-          repo: 'https://github.com/mozilla-releng/staging-focus-android',
           enableReleaseEta: false,
         },
       ],

--- a/frontend/src/configs/development.js
+++ b/frontend/src/configs/development.js
@@ -78,7 +78,7 @@ module.exports = {
     },
     {
       product: 'fenix',
-      prettyName: 'Fenix',
+      prettyName: 'Deprecated Fenix',
       appName: 'fenix',
       branches: [
         {
@@ -97,7 +97,7 @@ module.exports = {
     },
     {
       product: 'firefox-android',
-      prettyName: 'Firefox Android (Android-Components, Focus)',
+      prettyName: 'Firefox Android (Android-Components, Fenix, Focus)',
       appName: 'firefox-android',
       branches: [
         {

--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -105,7 +105,7 @@ module.exports = {
     },
     {
       product: 'fenix',
-      prettyName: 'Fenix',
+      prettyName: 'Deprecated Fenix',
       appName: 'fenix',
       branches: [
         {
@@ -124,7 +124,7 @@ module.exports = {
     },
     {
       product: 'firefox-android',
-      prettyName: 'Firefox Android (Android-Components, Focus)',
+      prettyName: 'Firefox Android (Android-Components, Fenix, Focus)',
       appName: 'firefox-android',
       branches: [
         {

--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -123,25 +123,6 @@ module.exports = {
       enablePartials: false,
     },
     {
-      product: 'android-components',
-      prettyName: 'Deprecated Android-Components',
-      appName: 'android-components',
-      branches: [
-        {
-          branch: '',
-        },
-      ],
-      repositories: [
-        {
-          prettyName: 'Android monorepo',
-          project: 'firefox-android',
-          repo: 'https://github.com/mozilla-mobile/firefox-android',
-          enableReleaseEta: false,
-        },
-      ],
-      enablePartials: false,
-    },
-    {
       product: 'firefox-android',
       prettyName: 'Firefox Android (Android-Components, Focus)',
       appName: 'firefox-android',
@@ -155,25 +136,6 @@ module.exports = {
           prettyName: 'Android monorepo',
           project: 'firefox-android',
           repo: 'https://github.com/mozilla-mobile/firefox-android',
-          enableReleaseEta: false,
-        },
-      ],
-      enablePartials: false,
-    },
-    {
-      product: 'focus-android',
-      prettyName: 'Deprecated Focus for Android',
-      appName: 'focus-android',
-      branches: [
-        {
-          branch: '',
-        },
-      ],
-      repositories: [
-        {
-          prettyName: 'Official repo',
-          project: 'focus-android',
-          repo: 'https://github.com/mozilla-mobile/focus-android',
           enableReleaseEta: false,
         },
       ],


### PR DESCRIPTION
⚠️ Land and deploy on production on Tuesday, February 14th, 2023. 