### PR TITLE
Bug 1815414 - Make `/version_txt` not error out on version numbers li…

### DIFF
--- a/api/src/shipit_api/admin/api.yml
+++ b/api/src/shipit_api/admin/api.yml
@@ -476,7 +476,14 @@ paths:
           content:
             text/plain:
               schema:
-                type: string
+                oneOf:
+                  - type: string
+                  # Bug 1815414 text/plain gets parsed as JSON object[1] when
+                  # connexion validates the output. This means "110.0" becomes
+                  # a number. That's why we're accepting both here.
+                  #
+                  # [1] https://github.com/spec-first/connexion/pull/205/files#diff-dfd9a45381cefd560da87f04925f10801539c6d5c45e4f1f3ecb08e06e9fe273R88
+                  - type: number
                 example: 1.0.0
   /github/xpis/{owner}/{repo}/{revision}:
     get:


### PR DESCRIPTION
…ke "111.0"

`connexion` validates HTTP responses differently whether they are json responses or not[1]. As weird as it seems, `text/plain` is considered to be json[2]. This behavior was added almost 7 years ago[3]. I don't think we should change `connexion` because it will likely introduce a regression.

Therefore, let's say `/version_txt` sometimes returns a string, sometimes a number.

[1] https://github.com/spec-first/connexion/blob/cdc8af157dd55cd40b9d60643416ba168ca12b86/connexion/decorators/response.py#L49
[2] https://github.com/spec-first/connexion/blob/cdc8af157dd55cd40b9d60643416ba168ca12b86/connexion/decorators/response.py#L80
[3] https://github.com/spec-first/connexion/pull/205/files#diff-dfd9a45381cefd560da87f04925f10801539c6d5c45e4f1f3ecb08e06e9fe273R88