### PR TITLE
Bug 1820194 - Support `firefox-android` when parsing existing product…

### DIFF
--- a/api/src/shipit_api/admin/product_details.py
+++ b/api/src/shipit_api/admin/product_details.py
@@ -345,7 +345,7 @@ def get_releases(
             # product_with_version looks like "Fennec-1.0". There is nothing after the version
             if "-" not in product_with_version:
                 raise ValueError(f'Invalid product_with_version "{product_with_version}". It must contain a -')
-            product_string, version_string = product_with_version.split("-")
+            product_string, version_string = product_with_version.rsplit("-", 1)
 
             # XXX Both Fennec and Fenix output to mobile_android.json. We don't want to
             # parse Fennec version number as if it were Fenix because the parser is


### PR DESCRIPTION
…-details files

Patch tested locally. I was able to get rebuild product details inside a docker container thanks to this patch. This wasn't the case before. 

[1] https://github.com/mozilla-releng/shipit#to-rebuild-product-details