### PR TITLE
Revert "Bug 1813994 - Remove deprecated mobile products"

### DIFF
--- a/api/src/shipit_api/admin/api.yml
+++ b/api/src/shipit_api/admin/api.yml
@@ -305,6 +305,7 @@ paths:
           type: string
           enum:
           - firefox
+          - fennec
           - devedition
           - pinebuild
       - name: branch
@@ -719,10 +720,14 @@ components:
           type: string
           example: firefox
           enum:
+          - android-components
           - devedition
           - pinebuild
+          - fenix
+          - fennec
           - firefox
           - firefox-android
+          - focus-android
           - thunderbird
         version:
           type: string
@@ -765,7 +770,7 @@ components:
           example: fennec_beta
         repo_url:
           type: string
-          example: https://github.com/mozilla-mobile/firefox-android
+          example: https://github.com/mozilla-mobile/fenix
     ReleaseStatus:
       required:
       - status
@@ -825,10 +830,14 @@ components:
           type: string
           example: firefox
           enum:
+          - android-components
           - devedition
           - pinebuild
+          - fenix
+          - fennec
           - firefox
           - firefox-android
+          - focus-android
           - thunderbird
         version:
           type: string
@@ -927,6 +936,7 @@ components:
           example: firefox
           enum:
           - firefox
+          - fennec
           - devedition
           - pinebuild
         branch:

--- a/api/src/shipit_api/admin/product_details.py
+++ b/api/src/shipit_api/admin/product_details.py
@@ -134,6 +134,7 @@ def to_format(d: datetime.datetime, format: str) -> str:
 
 
 def create_index_listing_html(folder: pathlib.Path, items: typing.Set[pathlib.Path]) -> str:
+
     folder = "/" / folder  # noqa : T484 Unsupported left operand type for / ("str")
     with io.StringIO() as html:
 
@@ -184,6 +185,7 @@ def create_index_listing(product_details: ProductDetails) -> ProductDetails:
 async def fetch_l10n_data(
     session: aiohttp.ClientSession, release: shipit_api.common.models.Release, raise_on_failure: bool, use_cache: bool = True
 ) -> typing.Tuple[shipit_api.common.models.Release, typing.Optional[ReleaseL10ns]]:
+
     # Fenix and some thunderbird on the betas don't have l10n in the repository
     if (
         Product(release.product) is Product.THUNDERBIRD
@@ -196,6 +198,7 @@ async def fetch_l10n_data(
         Product.FIREFOX: "browser/locales/l10n-changesets.json",
         Product.DEVEDITION: "browser/locales/l10n-changesets.json",
         Product.PINEBUILD: "browser/locales/l10n-changesets.json",
+        Product.FENNEC: "mobile/locales/l10n-changesets.json",
         Product.THUNDERBIRD: "mail/locales/l10n-changesets.json",
     }[Product(release.product)]
     url = f"{shipit_api.common.config.HG_PREFIX}/{release.branch}/raw-file/{release.revision}/{url_file}"
@@ -229,6 +232,7 @@ async def fetch_l10n_data(
 
 
 def get_old_product_details(directory: str) -> ProductDetails:
+
     if not os.path.isdir(directory):
         return dict()
 
@@ -260,6 +264,7 @@ def get_releases_from_db(db_session: sqlalchemy.orm.Session, breakpoint_version:
 
 
 def get_product_categories(product: Product, version: str) -> typing.List[ProductCategory]:
+
     # typically, these are dot releases that are considered major
     SPECIAL_FIREFOX_MAJORS = ["14.0.1"]
     SPECIAL_THUNDERBIRD_MAJORS = ["14.0.1", "38.0.1"]
@@ -290,7 +295,7 @@ def get_product_categories(product: Product, version: str) -> typing.List[Produc
     else:
         categories_mapping.append((ProductCategory.ESR, shipit_api.common.config.CURRENT_ESR + r"(\.[0-9]+){1,2}esr$"))
 
-    for product_category, version_pattern in categories_mapping:
+    for (product_category, version_pattern) in categories_mapping:
         if re.match(version_pattern, version):
             categories.append(product_category)
 
@@ -327,6 +332,7 @@ def get_releases(
     details = dict()
 
     for product in products:
+
         #
         # get release details from the JSON files up to breakpoint_version
         #
@@ -721,7 +727,7 @@ def get_l10n(
     # populate with old data first, stripping the '1.0/' prefix
     data: ProductDetails = {file_.replace("1.0/", ""): content for file_, content in old_product_details.items() if file_.startswith("1.0/l10n/")}
 
-    for release, locales in releases_l10n.items():
+    for (release, locales) in releases_l10n.items():
         # XXX: for some reason we didn't generate l10n for devedition in old_product_details
         # XXX need anything for pinebuild here?
         if Product(release.product) is Product.DEVEDITION:
@@ -985,6 +991,7 @@ async def rebuild(
     breakpoint_version: typing.Optional[int],
     clean_working_copy: bool = True,
 ):
+
     secrets = [urllib.parse.urlparse(git_repo_url).password]
 
     # Sometimes we want to work from a clean working copy
@@ -1126,7 +1133,7 @@ async def rebuild(
     if shipit_api.common.config.PRODUCT_DETAILS_NEW_DIR.exists():
         shutil.rmtree(shipit_api.common.config.PRODUCT_DETAILS_NEW_DIR)
 
-    for file__, content in product_details.items():
+    for (file__, content) in product_details.items():
         new_file = shipit_api.common.config.PRODUCT_DETAILS_NEW_DIR / file__
 
         # we must ensure that all needed folders exists

--- a/api/src/shipit_api/admin/release.py
+++ b/api/src/shipit_api/admin/release.py
@@ -6,7 +6,8 @@
 import logging
 
 import requests
-from mozilla_version.gecko import DeveditionVersion, FirefoxVersion, ThunderbirdVersion
+from mozilla_version.fenix import FenixVersion  # TODO replace with MobileVersion
+from mozilla_version.gecko import DeveditionVersion, FennecVersion, FirefoxVersion, ThunderbirdVersion
 from mozilla_version.mobile import MobileVersion
 
 from shipit_api.common.config import SUPPORTED_FLAVORS
@@ -15,10 +16,14 @@ from shipit_api.common.product import Product, get_key
 logger = logging.getLogger(__name__)
 
 _VERSION_CLASS_PER_PRODUCT = {
+    Product.ANDROID_COMPONENTS: MobileVersion,
     Product.DEVEDITION: DeveditionVersion,
     Product.PINEBUILD: FirefoxVersion,
+    Product.FENIX: FenixVersion,
+    Product.FENNEC: FennecVersion,
     Product.FIREFOX: FirefoxVersion,
     Product.FIREFOX_ANDROID: MobileVersion,
+    Product.FOCUS_ANDROID: MobileVersion,
     Product.THUNDERBIRD: ThunderbirdVersion,
 }
 
@@ -32,11 +37,7 @@ def parse_version(product, version):
         except KeyError:
             raise ValueError(f"Product {product} versions are not supported")
 
-    try:
-        VersionClass = _VERSION_CLASS_PER_PRODUCT[product_enum]
-    except KeyError:
-        raise ValueError(f"Product {product} versions are not supported")
-
+    VersionClass = _VERSION_CLASS_PER_PRODUCT[product_enum]
     return VersionClass.parse(version)
 
 

--- a/api/src/shipit_api/admin/settings.py
+++ b/api/src/shipit_api/admin/settings.py
@@ -75,8 +75,11 @@ XPI_MOZILLAONLINE_PRIVILEGED_ADMIN_LDAP_GROUP = ["xpi_mozillaonline_admin"]
 LDAP_GROUPS = {
     "admin": ADMIN_LDAP_GROUP,
     "firefox-signoff": ["shipit_firefox"],
+    "fenix-signoff": ["shipit_mobile"],
+    "android-components-signoff": ["shipit_mobile"],
     "thunderbird-signoff": ["shipit_thunderbird"],
     "firefox-android-signoff": ["shipit_mobile"],
+    "focus-android-signoff": ["shipit_mobile"],
     # XPI signoffs. These are in flux.
     # Adding Releng as a backup to most of these, for bus factor. Releng should
     # only sign off if requested by someone in the appropriate group.
@@ -95,9 +98,13 @@ AUTH0_AUTH_SCOPES = dict()
 
 # releng signoff scopes
 for product in [
+    "android-components",
     "devedition",
+    "fenix",
+    "fennec",
     "firefox",
     "firefox-android",
+    "focus-android",
     "pinebuild",
 ]:
     scopes = {f"add_release/{product}": LDAP_GROUPS["firefox-signoff"], f"abandon_release/{product}": LDAP_GROUPS["firefox-signoff"]}
@@ -111,12 +118,15 @@ for product in [
 # Add scopes for enabling/disabling products
 AUTH0_AUTH_SCOPES.update(
     {
+        "disable_product/android-components": LDAP_GROUPS["firefox-signoff"],
         "disable_product/firefox": LDAP_GROUPS["firefox-signoff"],
         "disable_product/firefox-android": LDAP_GROUPS["firefox-android-signoff"],
+        "disable_product/fennec": LDAP_GROUPS["firefox-signoff"],
         "disable_product/devedition": LDAP_GROUPS["firefox-signoff"],
         "disable_product/pinebuild": LDAP_GROUPS["firefox-signoff"],
         "enable_product/firefox": LDAP_GROUPS["firefox-signoff"],
         "enable_product/firefox-android": LDAP_GROUPS["firefox-android-signoff"],
+        "enable_product/fennec": LDAP_GROUPS["firefox-signoff"],
         "enable_product/devedition": LDAP_GROUPS["firefox-signoff"],
         "enable_product/pinebuild": LDAP_GROUPS["firefox-signoff"],
     }
@@ -142,7 +152,9 @@ AUTH0_AUTH_SCOPES.update(
     {
         "github": list(
             set(
-                LDAP_GROUPS["firefox-android-signoff"]
+                LDAP_GROUPS["android-components-signoff"]
+                + LDAP_GROUPS["fenix-signoff"]
+                + LDAP_GROUPS["firefox-android-signoff"]
                 + LDAP_GROUPS["xpi_privileged_build"]
                 + LDAP_GROUPS["xpi_privileged_signoff"]
                 + LDAP_GROUPS["xpi_system_build"]
@@ -150,6 +162,7 @@ AUTH0_AUTH_SCOPES.update(
                 + LDAP_GROUPS["xpi_mozillaonline-privileged_signoff"]
                 + LDAP_GROUPS["xpi_mozillaonline-privileged_admin_signoff"]
                 + LDAP_GROUPS["xpi_normandy-privileged_signoff"]
+                + LDAP_GROUPS["focus-android-signoff"]
             )
         )
     }

--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -26,7 +26,7 @@ PRODUCT_DETAILS_CACHE_DIR = pathlib.Path(tempfile.gettempdir(), "product-details
 # breakpoint version will be served using static files. No related
 # product-details data will be generated if we decide to ship a dot release
 # with major version <= BREAKPOINT_VERSION. This includes Firefox (release,
-# esr, beta, devedition, pinebuild), and Thunderbird.
+# esr, beta, devedition, pinebuild), Fennec and Thunderbird.
 BREAKPOINT_VERSION = 101
 
 # When there is only one ESR release ESR_NEXT is set to '' and ESR_CURRENT is
@@ -469,20 +469,49 @@ SUPPORTED_FLAVORS = {
         {"name": "push_thunderbird", "in_previous_graph_ids": True},
         {"name": "ship_thunderbird", "in_previous_graph_ids": True},
     ],
+    "android-components": [{"name": "ship", "in_previous_graph_ids": True}],
+    "fenix": [
+        {"name": "promote", "in_previous_graph_ids": True},
+        {"name": "ship", "in_previous_graph_ids": True},
+    ],
     "firefox-android": [
         {"name": "promote", "in_previous_graph_ids": True},
         {"name": "push", "in_previous_graph_ids": True},
         {"name": "ship", "in_previous_graph_ids": True},
     ],
+    "focus-android": [
+        {"name": "promote", "in_previous_graph_ids": True},
+        {"name": "ship", "in_previous_graph_ids": True},
+    ],
 }
 
 SUPPORTED_MOBILE_REPO_NAMES = (
+    "fenix",
     "firefox-android",
+    "focus-android",
+    "staging-fenix",
     "staging-firefox-android",
+    "staging-focus-android",
 )
 
 XPI_LAX_SIGN_OFF = config("XPI_LAX_SIGN_OFF", default=False, cast=bool)
 SIGNOFFS = {
+    # 'projects/maple': {
+    #     'fennec': {
+    #         'ship_fennec': [
+    #             {
+    #                 'name': '[relman] Ship Fennec',
+    #                 'description': 'Publish Firefox for Android to Play Store',
+    #                 'permissions': 'firefox-signoff',  # an ldap group from LDAP_GROUPS in settings.py
+    #             },
+    #             {
+    #                 'name': '[releng] Ship Fennec',
+    #                 'description': 'Publish Firefox for Android to Play Store',
+    #                 'permissions': 'admin',  # an ldap group from LDAP_GROUPS in settings.py
+    #             },
+    #         ],
+    #     },
+    # },
     "xpi": {
         "privileged": {
             "promote": [

--- a/api/src/shipit_api/common/product.py
+++ b/api/src/shipit_api/common/product.py
@@ -3,14 +3,14 @@ import enum
 
 @enum.unique
 class Product(enum.Enum):
-    ANDROID_COMPONENTS = "android-components"  # Only used for product details
+    ANDROID_COMPONENTS = "android-components"
     DEVEDITION = "devedition"
     PINEBUILD = "pinebuild"
     FIREFOX = "firefox"
-    FENIX = "fenix"  # Only used for product details
-    FENNEC = "fennec"  # Only used for product details
+    FENIX = "fenix"
+    FENNEC = "fennec"
     THUNDERBIRD = "thunderbird"
-    FOCUS_ANDROID = "focus-android"  # Only used for product details
+    FOCUS_ANDROID = "focus-android"
     FIREFOX_ANDROID = "firefox-android"
 
 

--- a/api/src/shipit_api/public/api.py
+++ b/api/src/shipit_api/public/api.py
@@ -7,7 +7,8 @@ import logging
 from collections import defaultdict
 
 from flask import abort, current_app
-from mozilla_version.gecko import DeveditionVersion, FirefoxVersion, ThunderbirdVersion
+from mozilla_version.fenix import FenixVersion
+from mozilla_version.gecko import DeveditionVersion, FennecVersion, FirefoxVersion, ThunderbirdVersion
 from mozilla_version.mobile import MobileVersion
 from werkzeug.exceptions import BadRequest
 
@@ -17,11 +18,15 @@ from shipit_api.common.product import Product
 logger = logging.getLogger(__name__)
 
 VERSION_CLASSES = {
+    Product.ANDROID_COMPONENTS.value: MobileVersion,
     Product.DEVEDITION.value: DeveditionVersion,
     # XXX revisit when we know how pinebuild will be versioned
     Product.PINEBUILD.value: FirefoxVersion,
+    Product.FENIX.value: FenixVersion,
+    Product.FENNEC.value: FennecVersion,
     Product.FIREFOX.value: FirefoxVersion,
     Product.FIREFOX_ANDROID.value: MobileVersion,
+    Product.FOCUS_ANDROID.value: MobileVersion,
     Product.THUNDERBIRD.value: ThunderbirdVersion,
 }
 

--- a/api/src/shipit_api/public/api.yml
+++ b/api/src/shipit_api/public/api.yml
@@ -158,10 +158,14 @@ components:
           type: string
           example: firefox
           enum:
+          - android-components
           - devedition
           - pinebuild
+          - fenix
+          - fennec
           - firefox
           - firefox-android
+          - focus-android
           - thunderbird
         version:
           type: string
@@ -302,6 +306,7 @@ components:
           example: firefox
           enum:
           - firefox
+          - fennec
           - devedition
           - pinebuild
         branch:

--- a/api/tests/test_release.py
+++ b/api/tests/test_release.py
@@ -8,7 +8,9 @@ from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
 import pytest
-from mozilla_version.gecko import DeveditionVersion, FirefoxVersion, ThunderbirdVersion
+from mozilla_version.fenix import FenixVersion
+from mozilla_version.gecko import DeveditionVersion, FennecVersion, FirefoxVersion, ThunderbirdVersion
+from mozilla_version.mobile import MobileVersion
 
 import backend_common.auth
 import backend_common.taskcluster
@@ -25,17 +27,20 @@ from shipit_api.common.product import Product
         (Product.DEVEDITION, "56.0b1", does_not_raise(), DeveditionVersion(56, 0, beta_number=1)),
         ("pinebuild", "56.0b1", does_not_raise(), FirefoxVersion(56, 0, beta_number=1)),
         (Product.PINEBUILD, "56.0b1", does_not_raise(), FirefoxVersion(56, 0, beta_number=1)),
+        ("fenix", "84.0.0-beta.2", does_not_raise(), FenixVersion(84, 0, 0, beta_number=2)),
+        (Product.FENIX, "84.0.0", does_not_raise(), FenixVersion(84, 0, 0)),
+        ("fennec", "68.2b3", does_not_raise(), FennecVersion(68, 2, beta_number=3)),
+        (Product.FENNEC, "68.2b3", does_not_raise(), FennecVersion(68, 2, beta_number=3)),
         ("firefox", "45.0", does_not_raise(), FirefoxVersion(45, 0)),
         (Product.FIREFOX, "45.0", does_not_raise(), FirefoxVersion(45, 0)),
         ("thunderbird", "60.8.0", does_not_raise(), ThunderbirdVersion(60, 8, 0)),
         (Product.THUNDERBIRD, "60.8.0", does_not_raise(), ThunderbirdVersion(60, 8, 0)),
         ("non-existing-product", "68.0", pytest.raises(ValueError), None),
-        # The following cases used to be valid. Let's be explicitly failing about them.
-        ("fennec", "68.2b3", pytest.raises(ValueError), None),
-        ("fennec_release", "68.1.1", pytest.raises(ValueError), None),  # When Fennec 68 was on the ESR branch
-        ("android-components", "107.0.3", pytest.raises(ValueError), None),
-        ("focus-android", "95.0.1", pytest.raises(ValueError), None),
-        ("fenix", "84.0.0", pytest.raises(ValueError), None),
+        # fennec_release used to be a valid value when we moved Fennec to ESR68
+        # https://github.com/mozilla/release-services/pull/2265
+        # Let's be explicitly failing about it.
+        ("fennec_release", "68.1.1", pytest.raises(ValueError), None),
+        (Product.FOCUS_ANDROID, "95.0.1", does_not_raise(), MobileVersion(95, 0, 1)),
     ),
 )
 def test_parse_version(product, version, expectation, result):
@@ -44,32 +49,29 @@ def test_parse_version(product, version, expectation, result):
 
 
 @pytest.mark.parametrize(
-    "product, version, partial_updates, expectation, result",
+    "product, version, partial_updates, result",
     (
-        ("firefox", "64.0", None, does_not_raise(), True),
-        ("thunderbird", "64.0", None, does_not_raise(), False),
-        ("firefox", "64.0.1", None, does_not_raise(), False),
-        ("thunderbird", "64.0.1", None, does_not_raise(), False),
-        ("firefox", "56.0b3", None, does_not_raise(), False),
-        ("firefox", "45.0esr", None, does_not_raise(), False),
-        ("firefox", "57.0", {"56.0b1": [], "55.0": []}, does_not_raise(), True),
-        ("firefox", "57.0", {"56.0": [], "55.0": []}, does_not_raise(), True),
-        ("firefox", "57.0.1", {"57.0": [], "56.0.1": [], "56.0": []}, does_not_raise(), False),
-        ("thunderbird", "57.0", {"56.0": [], "55.0": []}, does_not_raise(), False),
-        ("thunderbird", "57.0", {"56.0": [], "56.0b4": [], "55.0": []}, does_not_raise(), True),
-        ("firefox", "70.0b4", {"69.0b15": [], "69.0b16": [], "70.0b3": []}, does_not_raise(), False),
-        ("devedition", "70.0b4", {"70.0b3": [], "70.0b1": [], "70.0b2": []}, does_not_raise(), False),
-        ("pinebuild", "70.0b4", {"70.0b3": [], "70.0b1": [], "70.0b2": []}, does_not_raise(), False),
-        # The following cases used to be valid. Let's be explicitly failing about them.
-        ("fennec", "64.0", None, pytest.raises(ValueError), False),
-        ("android-components", "64.0", None, pytest.raises(ValueError), False),
-        ("focus-android", "64.0", None, pytest.raises(ValueError), False),
-        ("fenix", "64.0", None, pytest.raises(ValueError), False),
+        ("firefox", "64.0", None, True),
+        ("thunderbird", "64.0", None, False),
+        ("fennec", "64.0", None, False),  # "fennec_rc" does not exist anymore
+        ("firefox", "64.0.1", None, False),
+        ("thunderbird", "64.0.1", None, False),
+        ("fennec", "64.0.1", None, False),
+        ("firefox", "56.0b3", None, False),
+        ("fennec", "56.0b3", None, False),
+        ("firefox", "45.0esr", None, False),
+        ("firefox", "57.0", {"56.0b1": [], "55.0": []}, True),
+        ("firefox", "57.0", {"56.0": [], "55.0": []}, True),
+        ("firefox", "57.0.1", {"57.0": [], "56.0.1": [], "56.0": []}, False),
+        ("thunderbird", "57.0", {"56.0": [], "55.0": []}, False),
+        ("thunderbird", "57.0", {"56.0": [], "56.0b4": [], "55.0": []}, True),
+        ("firefox", "70.0b4", {"69.0b15": [], "69.0b16": [], "70.0b3": []}, False),
+        ("devedition", "70.0b4", {"70.0b3": [], "70.0b1": [], "70.0b2": []}, False),
+        ("pinebuild", "70.0b4", {"70.0b3": [], "70.0b1": [], "70.0b2": []}, False),
     ),
 )
-def test_is_rc(product, version, partial_updates, expectation, result):
-    with expectation:
-        assert is_rc(product, version, partial_updates) == result
+def test_is_rc(product, version, partial_updates, result):
+    assert is_rc(product, version, partial_updates) == result
 
 
 @pytest.mark.parametrize(
@@ -81,6 +83,12 @@ def test_is_rc(product, version, partial_updates, expectation, result):
         ("firefox", "45.0esr", "45.0.1esr"),
         ("firefox", "45.0.1esr", "45.0.2esr"),
         ("firefox", "45.2.1esr", "45.2.2esr"),
+        ("fennec", "68.1b2", "68.1b3"),
+        ("fenix", "84.0.0-beta.2", "84.0.0-beta.3"),
+        ("fenix", "84.0.0-rc.1", "84.0.0-rc.2"),
+        ("fenix", "84.0.0", "84.0.1"),
+        ("android-components", "84.0.0", "84.0.1"),
+        ("focus-android", "95.0.0", "95.0.1"),
         ("firefox-android", "108.0.0", "108.0.1"),
         ("firefox-android", "109.0", "109.0.1"),
     ),

--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -79,6 +79,25 @@ module.exports = {
       canTogglePartials: true,
     },
     {
+      product: 'fenix',
+      prettyName: 'Deprecated Fenix',
+      appName: 'fenix',
+      branches: [
+        {
+          branch: '',
+        },
+      ],
+      repositories: [
+        {
+          prettyName: 'Staging fork',
+          project: 'staging-fenix',
+          repo: 'https://github.com/mozilla-releng/staging-fenix',
+          enableReleaseEta: false,
+        },
+      ],
+      enablePartials: false,
+    },
+    {
       product: 'firefox-android',
       prettyName: 'Firefox Android (Android-Components, Fenix, Focus)',
       appName: 'firefox-android',

--- a/frontend/src/configs/development.js
+++ b/frontend/src/configs/development.js
@@ -77,6 +77,25 @@ module.exports = {
       enablePartials: false,
     },
     {
+      product: 'fenix',
+      prettyName: 'Deprecated Fenix',
+      appName: 'fenix',
+      branches: [
+        {
+          branch: '',
+        },
+      ],
+      repositories: [
+        {
+          prettyName: 'Staging fork',
+          project: 'staging-fenix',
+          repo: 'https://github.com/mozilla-releng/staging-fenix',
+          enableReleaseEta: false,
+        },
+      ],
+      enablePartials: false,
+    },
+    {
       product: 'firefox-android',
       prettyName: 'Firefox Android (Android-Components, Fenix, Focus)',
       appName: 'firefox-android',

--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -104,6 +104,25 @@ module.exports = {
       enablePartials: true,
     },
     {
+      product: 'fenix',
+      prettyName: 'Deprecated Fenix',
+      appName: 'fenix',
+      branches: [
+        {
+          branch: '',
+        },
+      ],
+      repositories: [
+        {
+          prettyName: 'Official repo',
+          project: 'fenix',
+          repo: 'https://github.com/mozilla-mobile/fenix',
+          enableReleaseEta: false,
+        },
+      ],
+      enablePartials: false,
+    },
+    {
       product: 'firefox-android',
       prettyName: 'Firefox Android (Android-Components, Fenix, Focus)',
       appName: 'firefox-android',


### PR DESCRIPTION
We removed too much and broke product-details: existing android-components/fenix/focus releases still need to be handled without throwing exceptions.

Reverts mozilla-releng/shipit#1295

Fixes #1302 