### PR TITLE
Fix k8s-image Dockerfile, round 2

### DIFF
--- a/taskcluster/docker/shipit/Dockerfile
+++ b/taskcluster/docker/shipit/Dockerfile
@@ -26,7 +26,7 @@ ADD topsrcdir/api/ /app/src
 ADD topsrcdir/api/docker.d/init.sh /app/docker.d/
 
 # --no-ansi is needed due to https://github.com/python-poetry/poetry/issues/7148
-RUN cd /app/src && APP_TYPE=$APP_TYPE poetry install --only-root --no-ansi && rm -rf /app/src
+RUN cd /app/src && APP_TYPE=$APP_TYPE poetry install --only-root --no-ansi
 
 ARG TASK_ID
 ARG APP_VERSION
@@ -37,7 +37,9 @@ ARG TASKCLUSTER_ROOT_URL
 RUN echo "{\"commit\": \"$VCS_HEAD_REV\", \"version\": \"$APP_VERSION\", \"source\": \"$VCS_HEAD_REPOSITORY\", \"build\": \"$TASKCLUSTER_ROOT_URL/tasks/$TASK_ID\"}" > /app/version.json
 
 ENV WEB_CONCURRENCY=3
+ENV APP_TYPE=${APP_TYPE}
+ENV FLASK_APP shipit_api.$APP_TYPE.flask:app
 USER app
-WORKDIR /app
+WORKDIR /app/src
 
-CMD ["/app/docker.d/init.sh", $APP_TYPE]
+ENTRYPOINT ["/bin/bash", "-c", "/app/docker.d/init.sh $APP_TYPE"]


### PR DESCRIPTION
There's a few things here:
* Don't delete /app/src (we need pyproject.toml from it at the very least, but there's really no harm in keeping the rest)
* Route APP_TYPE argument through an environment variable, so it actually gets interpreted
* Use ENTRYPOINT instead of CMD to ensure we execute through bash, and interpret APP_TYPE
* Set FLASK_APP environment variable, because the worker process relies on it. (Ideally we'd launch the worker through init.sh as well and avoid the need to set this variable in the Dockerfile, but that's more than I probably ought to do for a bustage fix.)

While testing this, I did discover that product details updates on dev are broken -- but I'm pretty sure this is unrelated (it's a username/password error - probably fallout from credential rotations...)