### PR TITLE
don't include cached tasks in release promotion existing tasks

### DIFF
--- a/api/src/shipit_api/admin/tasks.py
+++ b/api/src/shipit_api/admin/tasks.py
@@ -208,6 +208,7 @@ def generate_phases(release, common_input, verify_supported_flavors):
         input_ = copy.deepcopy(common_input)
         input_["release_promotion_flavor"] = phase["name"]
         input_["previous_graph_ids"] = list(previous_graph_ids)
+        input_["rebuild_kinds"] = ["docker-image", "fetch", "packages", "toolchain"]
 
         hook = generate_action_hook(task_group_id=decision_task_id, action_name="release-promotion", actions=actions, parameters=parameters, input_=input_)
         hook_no_context = {k: v for k, v in hook.items() if k != "context"}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1835689 has a gory breakdown of this but the short version is that by including cache tasks in existing_tasks, we can't pick up new cached tasks without a new revision. By adding the kinds that are cached to `rebuild_kinds` we will _not_ replace them as part of `existing_tasks`, but instead replace them as part of the `IndexSearch` optimization (if a matching cached version is found).

I've tested this to the extent that it's possible on Try by running a release promotion graph with and without the change. In both cases the set of tasks generated was identical (meaning we won't run a different set of tasks with this change). I also noted the difference in the optimization summary from each: Before: Replaced 232 tasks by existing_tasks during optimization After: Replaced 92 tasks by existing_tasks, 140 tasks by index-search (index-search) during optimization.

(92+140 = 232)