### PR TITLE
Revert "don't include cached tasks in release promotion existing tasks"

### DIFF
--- a/api/src/shipit_api/admin/tasks.py
+++ b/api/src/shipit_api/admin/tasks.py
@@ -208,7 +208,6 @@ def generate_phases(release, common_input, verify_supported_flavors):
         input_ = copy.deepcopy(common_input)
         input_["release_promotion_flavor"] = phase["name"]
         input_["previous_graph_ids"] = list(previous_graph_ids)
-        input_["rebuild_kinds"] = ["docker-image", "fetch", "packages", "toolchain"]
 
         hook = generate_action_hook(task_group_id=decision_task_id, action_name="release-promotion", actions=actions, parameters=parameters, input_=input_)
         hook_no_context = {k: v for k, v in hook.items() if k != "context"}


### PR DESCRIPTION
Setting rebuild_kinds in shipit overrides the project's release-promotion configuration, which for XPI meant we were reusing old builds instead of current ones based on the right revision.

It might be safer to do this in the relpro action and/or config, per-project or in mozilla-taskgraph, to avoid this sort of side effect?

Reverts mozilla-releng/shipit#1322