### PR TITLE
Set Thunderbird release branch to comm-esr115.

### DIFF
--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -77,7 +77,7 @@ IOS_VERSION = ""
 LATEST_THUNDERBIRD_ALPHA_VERSION = "54.0a2"
 LATEST_THUNDERBIRD_NIGHTLY_VERSION = "117.0a1"
 # TODO: Need to update this every cycle
-THUNDERBIRD_RELEASE_BRANCH = "releases/comm-esr102"
+THUNDERBIRD_RELEASE_BRANCH = "releases/comm-esr115"
 THUNDERBIRD_BETA_BRANCH = "releases/comm-beta"
 
 # Mixed


### PR DESCRIPTION
The Thunderbird website relies on product-details to set download links correctly. With this change, product-details will reflect the 115  version rather than the 102 version.