### PR TITLE
Stop keying SIGNOFFS by branch

### DIFF
--- a/api/src/shipit_api/common/models.py
+++ b/api/src/shipit_api/common/models.py
@@ -160,7 +160,7 @@ class Release(db.Model, ReleaseBase):
     def phase_signoffs(self, phase):
         return [
             Signoff(uid=slugid.nice(), name=req["name"], description=req["description"], permissions=req["permissions"])
-            for req in SIGNOFFS.get(self.branch, {}).get(self.product, {}).get(phase, [])
+            for req in SIGNOFFS.get(self.product, {}).get(phase, [])
         ]
 
     @property


### PR DESCRIPTION
This change is safe to make because the only entry in the SIGNOFFS object is `xpi`, and `xpi` has separate logic later on in this file (so this change won't impact that).

I believe the current format of keying by branch -> product -> phase was likely implemented with Gecko in mind and multiple products residing within Gecko. E.g, mozilla-beta -> firefox -> promote.

However, it doesn't make sense for Github projects like app-services (or soon VPN) where the branches are dynamic, e.g `release-v117`. Seeing as we don't currently use SIGNOFFS anywhere in Gecko, I figured it was just easiest to remove the `branch` key which is the behaviour we want in Github land. If we ever want to support different signoff rules for different Gecko branches, we'd need to re-implement that in a better way. However for now we ain't gonna need it.