### PR TITLE
Enable firefox-android release promotion on try (bug 1825123)

### DIFF
--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -468,6 +468,9 @@ SUPPORTED_FLAVORS = {
         {"name": "promote", "in_previous_graph_ids": True},
         {"name": "push", "in_previous_graph_ids": True},
         {"name": "ship", "in_previous_graph_ids": True},
+        {"name": "promote_android", "in_previous_graph_ids": True},
+        {"name": "push_android", "in_previous_graph_ids": True},
+        {"name": "ship_android", "in_previous_graph_ids": True},
     ],
     "app-services": [
         {"name": "promote", "in_previous_graph_ids": True},

--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -69,6 +69,14 @@ module.exports = {
         {
           branch: '',
         },
+        {
+          prettyName: 'Try',
+          project: 'try',
+          branch: 'try',
+          repo: 'https://hg.mozilla.org/try',
+          enableReleaseEta: false,
+          versionFile: 'mobile/android/version.txt',
+        },
       ],
       repositories: [
         {

--- a/frontend/src/configs/development.js
+++ b/frontend/src/configs/development.js
@@ -68,6 +68,14 @@ module.exports = {
         {
           branch: '',
         },
+        {
+          prettyName: 'Try',
+          project: 'try',
+          branch: 'try',
+          repo: 'https://hg.mozilla.org/try',
+          enableReleaseEta: false,
+          versionFile: 'mobile/android/version.txt',
+        },
       ],
       repositories: [
         {

--- a/frontend/src/views/NewRelease/index.jsx
+++ b/frontend/src/views/NewRelease/index.jsx
@@ -237,16 +237,13 @@ export default function NewRelease() {
   const renderBranchesSelect = () => {
     let branches;
 
-    if (
+    if (selectedRepository.branches && selectedRepository.branches.length > 0) {
+      branches = selectedRepository.branches;
+    } else if (
       selectedProduct.branches &&
       selectedProduct.branches.some(b => !!b.branch)
     ) {
       branches = selectedProduct.branches;
-    } else if (
-      selectedRepository.branches &&
-      selectedRepository.branches.length > 0
-    ) {
-      branches = selectedRepository.branches;
     }
 
     return (


### PR DESCRIPTION
- add new phases to the API for the firefox-android product to match what the new tasks are called
- add the try repo as an option for firefox-android builds on dev and development environments