### PR TITLE
Add mozilla-vpn-client and addons to shipit

### DIFF
--- a/api/src/shipit_api/admin/api.yml
+++ b/api/src/shipit_api/admin/api.yml
@@ -722,6 +722,8 @@ components:
           - devedition
           - firefox
           - firefox-android
+          - mozilla-vpn-addons
+          - mozilla-vpn-client
           - thunderbird
         version:
           type: string
@@ -832,6 +834,8 @@ components:
           - firefox
           - firefox-android
           - focus-android
+          - mozilla-vpn-addons
+          - mozilla-vpn-client
           - thunderbird
         version:
           type: string

--- a/api/src/shipit_api/admin/release.py
+++ b/api/src/shipit_api/admin/release.py
@@ -9,6 +9,7 @@ import requests
 from mozilla_version.fenix import FenixVersion  # TODO replace with MobileVersion
 from mozilla_version.gecko import DeveditionVersion, FennecVersion, FirefoxVersion, GeckoVersion, ThunderbirdVersion
 from mozilla_version.mobile import MobileVersion
+from mozilla_version.version import BaseVersion
 
 from shipit_api.common.config import SUPPORTED_FLAVORS
 from shipit_api.common.product import Product, get_key
@@ -24,6 +25,8 @@ _VERSION_CLASS_PER_PRODUCT = {
     Product.FIREFOX: FirefoxVersion,
     Product.FIREFOX_ANDROID: MobileVersion,
     Product.FOCUS_ANDROID: MobileVersion,
+    Product.MOZILLA_VPN_ADDONS: BaseVersion,
+    Product.MOZILLA_VPN_CLIENT: BaseVersion,
     Product.THUNDERBIRD: ThunderbirdVersion,
 }
 

--- a/api/src/shipit_api/admin/settings.py
+++ b/api/src/shipit_api/admin/settings.py
@@ -79,6 +79,7 @@ LDAP_GROUPS = {
     "thunderbird-signoff": ["shipit_thunderbird"],
     "firefox-android-signoff": ["shipit_mobile"],
     "app-services-signoff": ["shipit_app_services"],
+    "vpn-signoff": ADMIN_LDAP_GROUP,
     # XPI signoffs. These are in flux.
     # Adding Releng as a backup to most of these, for bus factor. Releng should
     # only sign off if requested by someone in the appropriate group.
@@ -141,6 +142,20 @@ for phase in set(phases):
 app_services_ldap_groups = sorted(set(LDAP_GROUPS["app-services-signoff"] + LDAP_GROUPS["relman"]))
 AUTH0_AUTH_SCOPES.update({s: app_services_ldap_groups for s in scopes})
 
+# vpn scopes
+scopes = []
+for flavor in ("mozilla-vpn-client", "mozilla-vpn-addons"):
+    scopes.extend(
+        [
+            f"add_release/{flavor}",
+            f"abandon_release/{flavor}",
+        ]
+    )
+    phases = [i["name"] for i in SUPPORTED_FLAVORS.get(flavor, [])]
+    for phase in set(phases):
+        scopes.extend([f"schedule_phase/{flavor}/{phase}", f"phase_signoff/{flavor}/{phase}"])
+AUTH0_AUTH_SCOPES.update({s: LDAP_GROUPS["vpn-signoff"] for s in scopes})
+
 # other scopes
 AUTH0_AUTH_SCOPES.update({"rebuild_product_details": LDAP_GROUPS["firefox-signoff"], "update_release_status": []})
 
@@ -152,6 +167,7 @@ AUTH0_AUTH_SCOPES.update(
             set(
                 LDAP_GROUPS["app-services-signoff"]
                 + LDAP_GROUPS["firefox-android-signoff"]
+                + LDAP_GROUPS["vpn-signoff"]
                 + LDAP_GROUPS["xpi_privileged_build"]
                 + LDAP_GROUPS["xpi_privileged_signoff"]
                 + LDAP_GROUPS["xpi_system_build"]

--- a/api/src/shipit_api/admin/tasks.py
+++ b/api/src/shipit_api/admin/tasks.py
@@ -15,7 +15,7 @@ import yaml
 from backend_common.taskcluster import get_service
 from shipit_api.admin.github import extract_github_repo_owner_and_name, is_github_url
 from shipit_api.admin.release import is_rc
-from shipit_api.common.config import SUPPORTED_APP_SERVICES_REPO_NAMES, SUPPORTED_FLAVORS, SUPPORTED_MOBILE_REPO_NAMES
+from shipit_api.common.config import SUPPORTED_APP_SERVICES_REPO_NAMES, SUPPORTED_FLAVORS, SUPPORTED_MOBILE_REPO_NAMES, SUPPORTED_MOZILLAVPN_REPO_NAMES
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +37,8 @@ def get_trust_domain(repo_url, project, product):
             return "mobile"
         elif repo_name in SUPPORTED_APP_SERVICES_REPO_NAMES:
             return "app-services"
+        elif repo_name in SUPPORTED_MOZILLAVPN_REPO_NAMES:
+            return "mozillavpn"
         else:
             raise UnsupportedFlavor(f'Unable to know what to do with repo_owner "{repo_owner}" and repo_name "{repo_name}"')
     elif "comm" in project:
@@ -50,7 +52,7 @@ def get_trust_domain(repo_url, project, product):
 @lru_cache(maxsize=2048)
 def find_decision_task_id(repo_url, project, revision, product):
     trust_domain = get_trust_domain(repo_url, project, product)
-    if trust_domain in ("app-services", "mobile"):
+    if trust_domain in ("app-services", "mobile", "mozillavpn"):
         _, project = extract_github_repo_owner_and_name(repo_url)
 
     decision_task_route = f"{trust_domain}.v2.{project}.revision.{revision}.taskgraph.decision"

--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -476,6 +476,14 @@ SUPPORTED_FLAVORS = {
         {"name": "promote", "in_previous_graph_ids": True},
         {"name": "ship", "in_previous_graph_ids": True},
     ],
+    "mozilla-vpn-client": [
+        {"name": "promote-client", "in_previous_graph_ids": True},
+        {"name": "ship-client", "in_previous_graph_ids": True},
+    ],
+    "mozilla-vpn-addons": [
+        {"name": "promote-addons", "in_previous_graph_ids": True},
+        {"name": "ship-addons", "in_previous_graph_ids": True},
+    ],
 }
 
 SUPPORTED_MOBILE_REPO_NAMES = (
@@ -486,6 +494,11 @@ SUPPORTED_MOBILE_REPO_NAMES = (
 SUPPORTED_APP_SERVICES_REPO_NAMES = (
     "application-services",
     "staging-application-services",
+)
+
+SUPPORTED_MOZILLAVPN_REPO_NAMES = (
+    "mozilla-vpn-client",
+    "staging-mozilla-vpn-client",
 )
 
 XPI_LAX_SIGN_OFF = config("XPI_LAX_SIGN_OFF", default=False, cast=bool)

--- a/api/src/shipit_api/common/product.py
+++ b/api/src/shipit_api/common/product.py
@@ -12,6 +12,8 @@ class Product(enum.Enum):
     THUNDERBIRD = "thunderbird"
     FOCUS_ANDROID = "focus-android"  # Only used for product details
     FIREFOX_ANDROID = "firefox-android"
+    MOZILLA_VPN_ADDONS = "mozilla-vpn-addons"
+    MOZILLA_VPN_CLIENT = "mozilla-vpn-client"
 
 
 @enum.unique

--- a/api/src/shipit_api/public/api.py
+++ b/api/src/shipit_api/public/api.py
@@ -10,6 +10,7 @@ from flask import abort, current_app
 from mozilla_version.fenix import FenixVersion
 from mozilla_version.gecko import DeveditionVersion, FennecVersion, FirefoxVersion, GeckoVersion, ThunderbirdVersion
 from mozilla_version.mobile import MobileVersion
+from mozilla_version.version import BaseVersion
 from werkzeug.exceptions import BadRequest
 
 from shipit_api.common.models import DisabledProduct, Phase, Release, XPIRelease
@@ -26,6 +27,8 @@ VERSION_CLASSES = {
     Product.FIREFOX.value: FirefoxVersion,
     Product.FIREFOX_ANDROID.value: MobileVersion,
     Product.FOCUS_ANDROID.value: MobileVersion,
+    Product.MOZILLA_VPN_ADDONS.value: BaseVersion,
+    Product.MOZILLA_VPN_CLIENT.value: BaseVersion,
     Product.THUNDERBIRD.value: ThunderbirdVersion,
 }
 

--- a/api/src/shipit_api/public/api.yml
+++ b/api/src/shipit_api/public/api.yml
@@ -166,6 +166,8 @@ components:
           - firefox
           - firefox-android
           - focus-android
+          - mozilla-vpn-addons
+          - mozilla-vpn-client
           - thunderbird
         version:
           type: string

--- a/frontend/src/components/Dashboard/menuItems.jsx
+++ b/frontend/src/components/Dashboard/menuItems.jsx
@@ -25,6 +25,26 @@ export default [
     ],
   },
   {
+    title: 'Security',
+    items: [
+      {
+        title: 'New',
+        to: '/new?group=security',
+        Icon: <AddBoxIcon />,
+      },
+      {
+        title: 'Pending',
+        to: '/?group=security',
+        Icon: <AutorenewIcon />,
+      },
+      {
+        title: 'Recent',
+        to: '/recent?group=security',
+        Icon: <CheckCircleIcon />,
+      },
+    ],
+  },
+  {
     title: 'Extensions',
     items: [
       {

--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -111,6 +111,50 @@ module.exports = {
         enablePartials: false,
       },
     ],
+    security: [
+      {
+        product: 'mozilla-vpn-client',
+        prettyName: 'Mozilla VPN Client',
+        appName: 'mozilla-vpn-client',
+        branches: [
+          {
+            branch: '',
+          },
+        ],
+        repositories: [
+          {
+            prettyName: 'Staging Mozilla VPN Client',
+            project: 'mozilla-vpn-client',
+            repo:
+              'https://github.com/mozilla-releng/staging-mozilla-vpn-client',
+            enableReleaseEta: false,
+            enableTreeherder: false,
+          },
+        ],
+        enablePartials: false,
+      },
+      {
+        product: 'mozilla-vpn-addons',
+        prettyName: 'Mozilla VPN Addons',
+        appName: 'mozilla-vpn-addons',
+        branches: [
+          {
+            branch: 'main',
+          },
+        ],
+        repositories: [
+          {
+            prettyName: 'Staging Mozilla VPN Client',
+            project: 'mozilla-vpn-client',
+            repo:
+              'https://github.com/mozilla-releng/staging-mozilla-vpn-client',
+            enableReleaseEta: false,
+            enableTreeherder: false,
+          },
+        ],
+        enablePartials: false,
+      },
+    ],
   },
   XPI_MANIFEST: {
     branch: 'main',

--- a/frontend/src/configs/development.js
+++ b/frontend/src/configs/development.js
@@ -110,6 +110,50 @@ module.exports = {
         enablePartials: false,
       },
     ],
+    security: [
+      {
+        product: 'mozilla-vpn-client',
+        prettyName: 'Mozilla VPN Client',
+        appName: 'mozilla-vpn-client',
+        branches: [
+          {
+            branch: '',
+          },
+        ],
+        repositories: [
+          {
+            prettyName: 'Staging Mozilla VPN Client',
+            project: 'mozilla-vpn-client',
+            repo:
+              'https://github.com/mozilla-releng/staging-mozilla-vpn-client',
+            enableReleaseEta: false,
+            enableTreeherder: false,
+          },
+        ],
+        enablePartials: false,
+      },
+      {
+        product: 'mozilla-vpn-addons',
+        prettyName: 'Mozilla VPN Addons',
+        appName: 'mozilla-vpn-addons',
+        branches: [
+          {
+            branch: 'main',
+          },
+        ],
+        repositories: [
+          {
+            prettyName: 'Staging Mozilla VPN Client',
+            project: 'mozilla-vpn-client',
+            repo:
+              'https://github.com/mozilla-releng/staging-mozilla-vpn-client',
+            enableReleaseEta: false,
+            enableTreeherder: false,
+          },
+        ],
+        enablePartials: false,
+      },
+    ],
   },
   XPI_MANIFEST: {
     branch: 'main',

--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -149,6 +149,48 @@ module.exports = {
         enablePartials: false,
       },
     ],
+    security: [
+      {
+        product: 'mozilla-vpn-client',
+        prettyName: 'Mozilla VPN Client',
+        appName: 'mozilla-vpn-client',
+        branches: [
+          {
+            branch: '',
+          },
+        ],
+        repositories: [
+          {
+            prettyName: 'Mozilla VPN Client',
+            project: 'mozilla-vpn-client',
+            repo: 'https://github.com/mozilla-mobile/mozilla-vpn-client',
+            enableReleaseEta: false,
+            enableTreeherder: false,
+          },
+        ],
+        enablePartials: false,
+      },
+      {
+        product: 'mozilla-vpn-addons',
+        prettyName: 'Mozilla VPN Addons',
+        appName: 'mozilla-vpn-addons',
+        branches: [
+          {
+            branch: 'main',
+          },
+        ],
+        repositories: [
+          {
+            prettyName: 'Mozilla VPN Client',
+            project: 'mozilla-vpn-client',
+            repo: 'https://github.com/mozilla-mobile/mozilla-vpn-client',
+            enableReleaseEta: false,
+            enableTreeherder: false,
+          },
+        ],
+        enablePartials: false,
+      },
+    ],
   },
   XPI_MANIFEST: {
     branch: 'main',


### PR DESCRIPTION
This also allows the release views (new, pending, releases) to take a "group" via url parameter. Only repositories configured under said group will be shown. The `PRODUCTS` key in the configuration is refactored such that projects are listed under the specified group. By default, "firefox" is used if no group was specified via param.

This way we can add new groups to the dropdown without needing separate views for each one.