### PR TITLE
fix: update 'get_taskgraph_config' to new Taskgraph v7 path

### DIFF
--- a/api/src/shipit_api/admin/github.py
+++ b/api/src/shipit_api/admin/github.py
@@ -186,7 +186,7 @@ def get_xpi_manifest(owner, repo, ref):
 
 
 def get_taskgraph_config(owner, repo, ref):
-    config = yaml.safe_load(get_file_from_github(owner, repo, "taskcluster/ci/config.yml", ref))
+    config = yaml.safe_load(get_file_from_github(owner, repo, "taskcluster/config.yml", ref))
     return config
 
 


### PR DESCRIPTION
This function is only used by `xpi-manifest` which is now updated to Taskgraph v7. So we shouldn't need to continue supporting the old path.