### PR TITLE
admin: find trust domain based on repo rather than product config

### DIFF
--- a/api/products.yml
+++ b/api/products.yml
@@ -11,7 +11,6 @@ app-services:
   phases:
   - promote
   - ship
-  firefox-ci-trust-domain: app-services
   repo-url: https://github.com/mozilla/application-services
   version-class: "mozilla_version.gecko.GeckoVersion"
 devedition:
@@ -23,7 +22,6 @@ devedition:
   - promote_devedition
   - push_devedition
   - ship_devedition
-  firefox-ci-trust-domain: gecko
   version-class: "mozilla_version.gecko.DeveditionVersion"
 fenix:
   legacy: true
@@ -40,7 +38,6 @@ firefox:
   - promote_firefox
   - push_firefox
   - ship_firefox
-  firefox-ci-trust-domain: gecko
   version-class: "mozilla_version.gecko.FirefoxVersion"
 firefox-android:
   can-be-disabled: true
@@ -54,7 +51,6 @@ firefox-android:
   - promote_android
   - push_android
   - ship_android
-  firefox-ci-trust-domain: mobile
   repo-url: https://github.com/mozilla-mobile/firefox-android
   version-class: "mozilla_version.mobile.MobileVersion"
 focus-android:
@@ -66,7 +62,6 @@ mozilla-vpn-addons:
   phases:
   - promote-addons
   - ship-addons
-  firefox-ci-trust-domain: mozillavpn
   repo-url: https://github.com/mozilla-mobile/mozilla-vpn-client
   version-class: "mozilla_version.version.BaseVersion"
 mozilla-vpn-client:
@@ -75,7 +70,6 @@ mozilla-vpn-client:
   phases:
   - promote-client
   - ship-client
-  firefox-ci-trust-domain: mozillavpn
   repo-url: https://github.com/mozilla-mobile/mozilla-vpn-client
   version-class: "mozilla_version.version.BaseVersion"
 thunderbird:
@@ -85,5 +79,4 @@ thunderbird:
   - promote_thunderbird
   - push_thunderbird
   - ship_thunderbird
-  firefox-ci-trust-domain: comm
   version-class: "mozilla_version.gecko.ThunderbirdVersion"

--- a/api/src/backend_common/__init__.py
+++ b/api/src/backend_common/__init__.py
@@ -16,6 +16,7 @@ from deepmerge import merge_or_raise
 EXTENSIONS = ["dockerflow", "log", "security", "cors", "api", "auth", "pulse", "db"]
 
 _PRODUCT_YML_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "products.yml"))
+_TRUST_DOMAIN_YML_PATH = os.path.realpath(os.path.join(os.path.dirname(__file__), "..", "..", "trust-domains.yml"))
 _MANDATORY_KEYS_IN_PRODUCT_YML = ("version-class",)
 
 logger = logging.getLogger(__name__)
@@ -122,3 +123,9 @@ def _check_mandatory_keys_are_provided(products_config):
                 product_config[key]
             except KeyError:
                 raise KeyError(f"In {_PRODUCT_YML_PATH}: {product_name} doesn't define key '{key}'")
+
+
+@cache
+def get_trust_domains():
+    with open(_TRUST_DOMAIN_YML_PATH) as f:
+        return yaml.safe_load(f)

--- a/api/src/shipit_api/admin/tasks.py
+++ b/api/src/shipit_api/admin/tasks.py
@@ -12,7 +12,7 @@ import jsone
 import requests
 import yaml
 
-from backend_common import get_products_config
+from backend_common import get_trust_domains
 from backend_common.taskcluster import get_service
 from shipit_api.admin.github import extract_github_repo_owner_and_name
 from shipit_api.admin.release import is_rc
@@ -31,21 +31,20 @@ class ArtifactNotFound(Exception):
     pass
 
 
-def get_trust_domain(project, product):
-    # XPI doesn't have any products defined in products.yml
-    if "xpi" in project:
+def get_trust_domain(repo_url, product):
+    # XPI doesn't set repo_url
+    if "xpi" == product:
         return "xpi"
-    products_config = get_products_config()
-    product_config = products_config[product]
-    try:
-        return product_config["firefox-ci-trust-domain"]
-    except KeyError:
-        raise KeyError(f"Product '{product}' does not define 'firefox-ci-trust-domain'")
+    trust_domains = get_trust_domains()
+    for trust_domain in trust_domains:
+        if repo_url in trust_domains[trust_domain]:
+            return trust_domain
+    raise KeyError(f"Can't find trust domain for repository {repo_url}")
 
 
 @lru_cache(maxsize=2048)
 def find_decision_task_id(repo_url, project, revision, product):
-    trust_domain = get_trust_domain(project, product)
+    trust_domain = get_trust_domain(repo_url, product)
     if trust_domain in ("app-services", "mobile", "mozillavpn"):
         _, project = extract_github_repo_owner_and_name(repo_url)
 

--- a/api/tests/test_tasks.py
+++ b/api/tests/test_tasks.py
@@ -114,3 +114,24 @@ def test_extract_our_flavors_warnings(caplog, avail_flavors, expected_records, e
     if expected_records > 0:
         assert caplog.records[0].levelname == "WARNING"
         assert expected_text in caplog.text
+
+
+@pytest.mark.parametrize(
+    "repo_url, product, expectation, trust_domain",
+    (
+        ("https://hg.mozilla.org/try", "firefox-android", does_not_raise(), "gecko"),
+        ("https://hg.mozilla.org/try", "firefox", does_not_raise(), "gecko"),
+        ("https://hg.mozilla.org/releases/mozilla-beta", "firefox-android", does_not_raise(), "gecko"),
+        ("https://hg.mozilla.org/mozilla-central", "firefox-android", pytest.raises(KeyError), None),
+        ("https://hg.mozilla.org/try-comm-central", "firefox-android", does_not_raise(), "comm"),
+        ("https://hg.mozilla.org/try-comm-central", "thunderbird", does_not_raise(), "comm"),
+        ("", "xpi", does_not_raise(), "xpi"),
+        ("https://github.com/mozilla-mobile/firefox-android", "firefox", does_not_raise(), "mobile"),
+        ("https://github.com/mozilla-mobile/firefox-android", "firefox-android", does_not_raise(), "mobile"),
+        ("https://github.com/mozilla-releng/staging-firefox-android", "firefox-android", does_not_raise(), "mobile"),
+        ("https://github.com/mozilla-mobile/mozilla-vpn-client", "firefox-android", does_not_raise(), "mozillavpn"),
+    ),
+)
+def test_get_trust_domain(repo_url, product, expectation, trust_domain):
+    with expectation:
+        assert tasks.get_trust_domain(repo_url, product) == trust_domain

--- a/api/trust-domains.yml
+++ b/api/trust-domains.yml
@@ -1,0 +1,20 @@
+---
+app-services:
+  - https://github.com/mozilla/application-services
+comm:
+  - https://hg.mozilla.org/releases/comm-beta
+  - https://hg.mozilla.org/releases/comm-esr115
+  - https://hg.mozilla.org/try-comm-central
+gecko:
+  - https://hg.mozilla.org/releases/mozilla-beta
+  - https://hg.mozilla.org/releases/mozilla-release
+  - https://hg.mozilla.org/releases/mozilla-esr115
+  - https://hg.mozilla.org/try
+mobile:
+  - https://github.com/mozilla-mobile/firefox-android
+  - https://github.com/mozilla-releng/staging-firefox-android
+mozillavpn:
+  - https://github.com/mozilla-mobile/mozilla-vpn-client
+xpi:
+  - https://github.com/mozilla-extensions/xpi-manifest
+  - https://github.com/mozilla-releng/staging-xpi-manifest


### PR DESCRIPTION
This fixes a regression where we would treat try as a github repo when creating a firefox-android staging release, because we assumed it should use the "mobile" trust domain.

Closes #1405