### PR TITLE
Bug 1859885 - Temporarily use Beta for comm-release partials

### DIFF
--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -93,6 +93,8 @@ module.exports = {
             project: 'comm-release',
             branch: 'releases/comm-release',
             repo: 'https://hg.mozilla.org/releases/comm-release',
+            alternativeBranch: 'releases/comm-beta',
+            alternativeRepo: 'https://hg.mozilla.org/releases/comm-beta',
             enableReleaseEta: false,
             disableable: false,
           },


### PR DESCRIPTION
Handle the proverbial chicken and egg scenario. Partial updates for comm-release cannot be generated as there's no prior releases in Shipit's database to use as a base. Turning on "canTogglePartials" for Thunderbird won't help since Taskgraph expects to receive a "partial_updates" field in the promote, push, and ship payloads. That's not easy to change due to the config.yml schema.

For now, use comm-beta as an alternate repository for partials, like for new esr repositories. Once a few release candidates have shipped this can be removed.