### PR TITLE
chore(api): remove transient 'itsdangerous' dependency from pyproject…

### DIFF
--- a/api/poetry.lock
+++ b/api/poetry.lock
@@ -2645,4 +2645,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "b48237c103db9090de996d1fd1852e4a2a98f4f6de4700e013ffe027ebacb118"
+content-hash = "dc45b016e7aac7185893f5b6573dbb0efb4fb4d801ae0c120222e1061eac1c15"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -57,9 +57,6 @@ flask = "*"
 flask_cors = "*"
 flask_migrate = "*"
 flask_talisman = "*"
-# flask_oidc imports JSONWebSignatureSerializer which was removed in 2.1+
-# https://github.com/pallets/itsdangerous/pull/273
-itsdangerous = "<2.1"
 mozilla-version = "*"
 python-decouple = "*"
 sentry-sdk = {version = "*", extras = ["flask"]}


### PR DESCRIPTION
….toml

This was added to resolve an issue between `flask_oidc` and `itsdangerous` which has since been resolved upstream. We don't actually depend on `itsdangerous` directly.