### PR TITLE
Query the whattrainisitnow release schedule API instead of hard-coding scheduled release dates

### DIFF
--- a/api/src/shipit_api/admin/product_details.py
+++ b/api/src/shipit_api/admin/product_details.py
@@ -651,7 +651,7 @@ async def fetch_firefox_release_schedule_data(releases: typing.List[shipit_api.c
             logger.debug(f"Fetched {url}")
             previous_nightly_version_schedule = await response.json()
     except Exception:
-        logger.info("Failed to fetch %s, %s", url)
+        logger.info("Failed to fetch %s", url)
         raise
     date_format = "%Y-%m-%d"
     last_softfreeze_date = from_isoformat(previous_nightly_version_schedule["soft_code_freeze"]).strftime(date_format)

--- a/api/src/shipit_api/admin/product_details.py
+++ b/api/src/shipit_api/admin/product_details.py
@@ -143,6 +143,21 @@ def from_format(s: str, format: str) -> datetime.datetime:
     return datetime.datetime.strptime(s, format)
 
 
+YMD_DATE_FORMAT = "%Y-%m-%d"
+
+
+def iso_to_ymd(s: str) -> str:
+    return from_isoformat(s).strftime(YMD_DATE_FORMAT)
+
+
+def datetime_to_ymd(d: datetime.datetime) -> str:
+    return d.strftime(YMD_DATE_FORMAT)
+
+
+def from_ymd_format(s: str) -> datetime.datetime:
+    return from_format(s, YMD_DATE_FORMAT)
+
+
 def create_index_listing_html(folder: pathlib.Path, items: typing.Set[pathlib.Path]) -> str:
     folder = "/" / folder  # noqa : T484 Unsupported left operand type for / ("str")
     with io.StringIO() as html:
@@ -653,9 +668,8 @@ async def fetch_firefox_release_schedule_data(releases: typing.List[shipit_api.c
     except Exception:
         logger.info("Failed to fetch %s", url)
         raise
-    date_format = "%Y-%m-%d"
-    last_softfreeze_date = from_isoformat(previous_nightly_version_schedule["soft_code_freeze"]).strftime(date_format)
-    last_merge_date = from_isoformat(previous_nightly_version_schedule["merge_day"]).strftime(date_format)
+    last_softfreeze_date = iso_to_ymd(previous_nightly_version_schedule["soft_code_freeze"])
+    last_merge_date = iso_to_ymd(previous_nightly_version_schedule["merge_day"])
     releases_after_last_merge_date = sorted(
         [
             release
@@ -671,12 +685,12 @@ async def fetch_firefox_release_schedule_data(releases: typing.List[shipit_api.c
     if not releases_after_last_merge_date:
         raise ValueError(f"No Firefox releases shipped after the last merge date ({last_merge_date})")
     first_release_after_last_merge_date = releases_after_last_merge_date[0]
-    last_release_date = first_release_after_last_merge_date.completed.strftime(date_format)
-    next_softfreeze_date = from_isoformat(current_nightly_version_schedule["soft_code_freeze"]).strftime(date_format)
-    next_merge_date = from_isoformat(current_nightly_version_schedule["merge_day"]).strftime(date_format)
-    next_release_date = (from_isoformat(current_nightly_version_schedule["merge_day"]) + datetime.timedelta(days=1)).strftime(date_format)
-    last_stringfreeze_date = (from_format(last_softfreeze_date, date_format) + datetime.timedelta(days=1)).strftime(date_format)
-    next_stringfreeze_date = (from_format(next_softfreeze_date, date_format) + datetime.timedelta(days=1)).strftime(date_format)
+    last_release_date = datetime_to_ymd(first_release_after_last_merge_date.completed)
+    next_softfreeze_date = iso_to_ymd(current_nightly_version_schedule["soft_code_freeze"])
+    next_merge_date = iso_to_ymd(current_nightly_version_schedule["merge_day"])
+    next_release_date = datetime_to_ymd(from_isoformat(current_nightly_version_schedule["merge_day"]) + datetime.timedelta(days=1))
+    last_stringfreeze_date = datetime_to_ymd(from_ymd_format(last_softfreeze_date) + datetime.timedelta(days=1))
+    next_stringfreeze_date = datetime_to_ymd(from_ymd_format(next_softfreeze_date) + datetime.timedelta(days=1))
     return {
         "LAST_SOFTFREEZE_DATE": last_softfreeze_date,
         "LAST_MERGE_DATE": last_merge_date,

--- a/api/src/shipit_api/admin/product_details.py
+++ b/api/src/shipit_api/admin/product_details.py
@@ -668,6 +668,8 @@ async def fetch_firefox_release_schedule_data(releases: typing.List[shipit_api.c
         ],
         key=lambda release: FirefoxVersion.parse(release.version),
     )
+    if not releases_after_last_merge_date:
+        raise ValueError(f"No Firefox releases shipped after the last merge date ({last_merge_date})")
     first_release_after_last_merge_date = releases_after_last_merge_date[0]
     last_release_date = first_release_after_last_merge_date.completed.strftime(date_format)
     next_softfreeze_date = from_isoformat(current_nightly_version_schedule["soft_code_freeze"]).strftime(date_format)

--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -5,7 +5,6 @@
 
 import pathlib
 import tempfile
-from datetime import datetime, timedelta
 from functools import cache
 
 from decouple import config
@@ -53,20 +52,6 @@ ESR_BRANCH_PREFIX = "releases/mozilla-esr"
 #
 # This version also defines the mobile nightly version (i.e.: Fenix)
 FIREFOX_NIGHTLY = "128.0a1"
-
-# The next 6 dates are information about the current and next release
-# They must be updated at the same time as FIREFOX_NIGHTLY
-# They can be found on https://whattrainisitnow.com/calendar/
-LAST_SOFTFREEZE_DATE = "2024-05-09"
-LAST_MERGE_DATE = "2024-05-13"
-LAST_RELEASE_DATE = "2024-05-14"
-NEXT_SOFTFREEZE_DATE = "2024-06-06"
-NEXT_MERGE_DATE = "2024-06-10"
-NEXT_RELEASE_DATE = "2024-06-11"
-
-DATE_FORMAT = "%Y-%m-%d"
-LAST_STRINGFREEZE_DATE = (datetime.strptime(LAST_SOFTFREEZE_DATE, DATE_FORMAT) + timedelta(days=1)).strftime(DATE_FORMAT)
-NEXT_STRINGFREEZE_DATE = (datetime.strptime(NEXT_SOFTFREEZE_DATE, DATE_FORMAT) + timedelta(days=1)).strftime(DATE_FORMAT)
 
 # Aurora has been replaced by Dev Edition, but some 3rd party applications may
 # still rely on this value.


### PR DESCRIPTION
Resolves #1461