### PR TITLE
Add a table to keep product channel versions and APIs to update them

### DIFF
--- a/api/src/shipit_api/admin/api.yml
+++ b/api/src/shipit_api/admin/api.yml
@@ -693,6 +693,167 @@ paths:
         "409":
           description: Already submitted
           content: {}
+  /versions/{product}/{channel}:
+    get:
+      summary: Get the current version for the given product channel
+      operationId: shipit_api.admin.api.get_product_channel_version
+      parameters:
+      - name: product
+        in: path
+        description: product name
+        required: true
+        schema:
+          type: string
+      - name: channel
+        in: path
+        description: product channel
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The current version for the given product channel
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: "127.0a1"
+        "404":
+          description: Product channel version not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "No version found for firefox release."
+    post:
+      summary: Create a new product channel version
+      operationId: shipit_api.admin.api.create_product_channel_version
+      parameters:
+        - name: product
+          in: path
+          description: The product name for which the version is to be updated
+          required: true
+          schema:
+            type: string
+        - name: channel
+          in: path
+          description: product channel
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Initial version for a new product channel
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                version:
+                  type: string
+                  example: "128.0a1"
+        required: true
+      responses:
+        "201":
+          description: Product channel version created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "A firefox nightly version was created successfully."
+                  version:
+                    type: string
+                    example: "128.0a1"
+                  product:
+                    type: string
+                    example: "firefox"
+                  channel:
+                    type: string
+                    example: "nightly"
+        "409":
+          description: Product channel version already exists
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "A firefox nightly version already exists."
+    put:
+      summary: Update an existing product channel's version
+      operationId: shipit_api.admin.api.update_product_channel_version
+      parameters:
+        - name: product
+          in: path
+          description: The product name for which the version is to be updated
+          required: true
+          schema:
+            type: string
+        - name: channel
+          in: path
+          description: product channel
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: A valid version for the product channel
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                version:
+                  type: string
+                  example: "129.0a1"
+        required: true
+      responses:
+        "200":
+          description: Product version updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "The version for firefox nightly was updated successfully."
+                  version:
+                    type: string
+                    example: "128.0a1"
+                  product:
+                    type: string
+                    example: "firefox"
+                  channel:
+                    type: string
+                    example: "nightly"
+        "409":
+          description: Product channel is already the given value
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "The firefox nightly version is already 128.0a1!"
+        "404":
+          description: Product channel version not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "No version found for firefox release."
+
+
 components:
   schemas:
     ReleaseInput:

--- a/api/src/shipit_api/admin/settings.py
+++ b/api/src/shipit_api/admin/settings.py
@@ -99,7 +99,8 @@ LDAP_GROUPS = {
 AUTH0_AUTH_SCOPES = assign_ldap_groups_to_scopes()
 
 # other scopes
-AUTH0_AUTH_SCOPES.update({"rebuild_product_details": LDAP_GROUPS["firefox-signoff"], "update_release_status": []})
+AUTH0_AUTH_SCOPES.update({"rebuild_product_details": LDAP_GROUPS["firefox-signoff"], "update_release_status": [], "create_product_channel_version/firefox": []})
+
 
 # Github scopes
 # The following scope gives permission to all github queries, inlcuding private repos

--- a/api/src/shipit_api/common/models.py
+++ b/api/src/shipit_api/common/models.py
@@ -264,3 +264,12 @@ class XPIRelease(db.Model, ReleaseBase):
             "completed": self.completed or "",
             "phases": [p.json for p in self.phases],
         }
+
+
+class Version(db.Model):
+    __tablename__ = "shipit_api_versions"
+    id = sa.Column(sa.Integer, primary_key=True)
+    product_name = sa.Column(sa.String, unique=True, nullable=False)
+    product_channel = sa.Column(sa.String, nullable=False)
+    current_version = sa.Column(sa.String, nullable=False)
+    __table_args__ = (sa.UniqueConstraint("product_name", "product_channel", name="_product_name_channel_uc"),)


### PR DESCRIPTION
This is an API that lets us store the current versions of FIREFOX_NIGHTLY, instead of hard-coding it, so we can update this data using an API from a `shipitscript` task. This is part of the solution to #1462 