### PR TITLE
Remove support for firefox-android github repo

### DIFF
--- a/api/products.yml
+++ b/api/products.yml
@@ -45,13 +45,9 @@ firefox-android:
   - shipit_firefox
   - shipit_relman
   phases:
-  - promote
-  - push
-  - ship
   - promote_android
   - push_android
   - ship_android
-  repo-url: https://github.com/mozilla-mobile/firefox-android
   version-class: "mozilla_version.mobile.MobileVersion"
 focus-android:
   legacy: true

--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -51,23 +51,12 @@ module.exports = {
         appName: 'firefox-android',
         branches: [
           {
-            branch: '',
-          },
-          {
             prettyName: 'Try',
             project: 'try',
             branch: 'try',
             repo: 'https://hg.mozilla.org/try',
             enableReleaseEta: false,
             versionFile: 'mobile/android/version.txt',
-          },
-        ],
-        repositories: [
-          {
-            prettyName: 'Staging Android monorepo',
-            project: 'staging-firefox-android',
-            repo: 'https://github.com/mozilla-releng/staging-firefox-android',
-            enableReleaseEta: false,
           },
         ],
         enablePartials: false,

--- a/frontend/src/configs/development.js
+++ b/frontend/src/configs/development.js
@@ -50,23 +50,12 @@ module.exports = {
         appName: 'firefox-android',
         branches: [
           {
-            branch: '',
-          },
-          {
             prettyName: 'Try',
             project: 'try',
             branch: 'try',
             repo: 'https://hg.mozilla.org/try',
             enableReleaseEta: false,
             versionFile: 'mobile/android/version.txt',
-          },
-        ],
-        repositories: [
-          {
-            prettyName: 'Staging Android monorepo',
-            project: 'staging-firefox-android',
-            repo: 'https://github.com/mozilla-releng/staging-firefox-android',
-            enableReleaseEta: false,
           },
         ],
         enablePartials: false,

--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -81,9 +81,6 @@ module.exports = {
         appName: 'firefox-android',
         branches: [
           {
-            branch: '',
-          },
-          {
             prettyName: 'Beta',
             project: 'mozilla-beta',
             branch: 'releases/mozilla-beta',
@@ -100,14 +97,6 @@ module.exports = {
             versionFile: 'mobile/android/version.txt',
             enableReleaseEta: true,
             disableable: false,
-          },
-        ],
-        repositories: [
-          {
-            prettyName: 'Android monorepo',
-            project: 'firefox-android',
-            repo: 'https://github.com/mozilla-mobile/firefox-android',
-            enableReleaseEta: false,
           },
         ],
         enablePartials: false,


### PR DESCRIPTION
125 is EOL, so this is no longer needed.

Fixes #1432
Fixes #1469 