### PR TITLE
Fix shell in public local dev container

### DIFF
--- a/api/Dockerfile.public
+++ b/api/Dockerfile.public
@@ -16,5 +16,6 @@ ENV WEB_CONCURRENCY=3
 USER app
 
 RUN poetry install --only main
+RUN poetry install --only dev
 
 CMD ["/app/docker.d/init.sh", "public"]


### PR DESCRIPTION
I forgot to add the shell to the public API's dev container.