### PR TITLE
api: allow enabling/disabling automated firefox-android releases (bug 1884740)

### DIFF
--- a/api/src/shipit_api/admin/api.yml
+++ b/api/src/shipit_api/admin/api.yml
@@ -296,6 +296,7 @@ paths:
           enum:
           - firefox
           - devedition
+          - firefox-android
       - name: branch
         in: query
         required: true
@@ -1064,6 +1065,7 @@ components:
           enum:
           - firefox
           - devedition
+          - firefox-android
         branch:
           type: string
           example: releases/mozilla-beta

--- a/api/src/shipit_api/public/api.yml
+++ b/api/src/shipit_api/public/api.yml
@@ -285,6 +285,7 @@ components:
           enum:
           - firefox
           - devedition
+          - firefox-android
         branch:
           type: string
           example: releases/mozilla-beta


### PR DESCRIPTION
I missed this in #1504 