### PR TITLE
ci: for pushes, only run taskcluster on actively used branches

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -6,7 +6,8 @@ policy:
 tasks:
     - $if: >
           (tasks_for == "github-pull-request" && event.action in ["opened", "reopened", "synchronize"])
-          || (tasks_for in ["github-push", "action", "cron"])
+          || (tasks_for in ["action", "cron"])
+          || (tasks_for == "github-push" && event.ref in ["refs/heads/main", "refs/heads/production", "refs/heads/dev"])
       then:
           $let:
               trustDomain: releng


### PR DESCRIPTION
Anything else should route through a PR. If we need other long lived branches in the future we can add them, and also add them to https://github.com/mozilla-releng/fxci-config/blob/main/projects.yml.