### PR TITLE
product-details: stop generating devedition l10n files

### DIFF
--- a/api/src/shipit_api/admin/product_details.py
+++ b/api/src/shipit_api/admin/product_details.py
@@ -845,6 +845,10 @@ def get_l10n(
     data: ProductDetails = {file_.replace("1.0/", ""): content for file_, content in old_product_details.items() if file_.startswith("1.0/l10n/")}
 
     for release, locales in releases_l10n.items():
+        # XXX: for some reason we didn't generate l10n for devedition in old_product_details
+        if Product(release.product) is Product.DEVEDITION:
+            continue
+
         data[f"l10n/{release.name}.json"] = {
             "locales": {locale: dict(changeset=content["revision"]) for locale, content in locales.items()},
             "submittedAt": with_default(release.created, to_isoformat, default=""),


### PR DESCRIPTION
This brings back a check removed by commit 055c149f "product-details: don't ask hg.mozilla.org for data we already have".  Commit fa95b9c8 "product-details: don't skip l10n for devedition entirely" re-added l10n fetches for devedition, so we again need to skip it in `get_l10n` to avoid committing these files
(https://github.com/mozilla-releng/shipit/issues/1588 was filed to consider whether we want to do something about it longer term).