### PR TITLE
Fix references to python39 related tasks

### DIFF
--- a/taskcluster/kinds/codecov/kind.yml
+++ b/taskcluster/kinds/codecov/kind.yml
@@ -17,14 +17,14 @@ jobs:
         description: "Upload coverage.xml to codecov.io"
         worker-type: t-linux
         worker:
-            docker-image: {in-tree: python39}
+            docker-image: {in-tree: python312}
             max-run-time: 1800
             env:
                 MOZ_FETCHES_DIR: /builds/worker/fetches
         scopes:
             - secrets:get:project/releng/shipit/ci
         dependencies:
-            tests: tests-api-python-39
+            tests: tests-api-python-312
         fetches:
             fetch:
                 - codecov-uploader

--- a/taskcluster/kinds/push-image/kind.yml
+++ b/taskcluster/kinds/push-image/kind.yml
@@ -22,7 +22,7 @@ task-defaults:
         max-run-time: 3600
     dependencies:
           tests-js: tests-frontend-node-14
-          tests-api: tests-api-python-39
+          tests-api: tests-api-python-312
     run:
         using: run-task
         checkout: false

--- a/taskcluster/kinds/push-js/kind.yml
+++ b/taskcluster/kinds/push-js/kind.yml
@@ -31,7 +31,7 @@ tasks:
             max-run-time: 3600
         dependencies:
               tests-js: tests-frontend-node-14
-              tests-api: tests-api-python-39
+              tests-api: tests-api-python-312
         run:
             command:
                 - sh


### PR DESCRIPTION
Those got missed when python was upgraded to 3.12 in 046826e96999bde08fdc33cce03c4576b89d8904