### PR TITLE
Create an issue template to point people to Bugzilla

### DIFF
--- a/.github/ISSUE_TEMPLATE/all-types-of-issues.md
+++ b/.github/ISSUE_TEMPLATE/all-types-of-issues.md
@@ -1,0 +1,10 @@
+---
+name: All types of issues
+about: Create a report to help us improve
+title: Please file issues on Bugzilla instead
+labels: ''
+assignees: ''
+
+---
+
+Please file issues [on Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=Release%20Engineering&component=Applications%3A%20Shipit).


### PR DESCRIPTION
If we turn off the Issues feature on the repo, then links of all previously created issues become 404. We still want to keep the history around.