### PR TITLE
Bug 1961246 - Add 'newtab' system addon to shipit

### DIFF
--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -453,7 +453,10 @@ def _get_phases_definitions(phases):
 
 SUPPORTED_FLAVORS = _get_supported_flavors()
 
-SYSTEM_ADDONS = ("webcompat",)
+SYSTEM_ADDONS = (
+    "newtab",
+    "webcompat",
+)
 
 XPI_LAX_SIGN_OFF = config("XPI_LAX_SIGN_OFF", default=False, cast=bool)
 SIGNOFFS = {


### PR DESCRIPTION
Unfortunately the per system addon LDAP groups require us to explicitly list system addons in shipit. It might be worth a follow-up refactoring to try and avoid this requirement. However there is also going to be a larger refactor around system addons and shipping them out of mozilla-central. So I think it's ok to just require a shipit deploy in the meantime.