### PR TITLE
Support finding version of xpis in firefox-main

### DIFF
--- a/api/src/shipit_api/admin/github.py
+++ b/api/src/shipit_api/admin/github.py
@@ -23,7 +23,7 @@ def _require_auth():
 @lru_cache(maxsize=10)
 def get_file_from_github(owner, repo, ref, path):
     allowed_files = get_allowed_github_files(owner, repo)
-    if path not in allowed_files:
+    if not any(af.fullmatch(path) for af in allowed_files):
         raise ValueError(f"Retrieving {path} not allowed for {owner}/{repo}!")
 
     path = unquote(path)

--- a/api/src/shipit_api/admin/github.py
+++ b/api/src/shipit_api/admin/github.py
@@ -237,6 +237,7 @@ def list_xpis(owner, repo, revision):
                     "manifest_revision": revision,
                     "directory": xpi.get("directory", ""),
                     "addon-type": xpi["addon-type"],
+                    "install_type": xpi.get("install-type", "yarn"),
                 }
             )
         except TypeError as exc:

--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -4,6 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pathlib
+import re
 import tempfile
 from functools import cache, lru_cache
 
@@ -537,16 +538,17 @@ ALLOW_PHASE_SKIPPING = {
 
 
 @lru_cache(maxsize=10)
-def get_allowed_github_files(owner: str, repo: str) -> set[str]:
+def get_allowed_github_files(owner: str, repo: str) -> set[re.Pattern]:
+    """Retrieve a set of compiled regexes that match allowed file paths."""
     allowed_paths = {
-        "taskcluster/config.yml",
-        "version.txt",
+        r"taskcluster/config.yml",
+        r"version.txt",
     }
 
     match (owner, repo):
         case ("mozilla-extensions", _):
-            allowed_paths.add("package.json")
+            allowed_paths.add(r"package.json")
         case ("mozilla-releng", "staging-xpi-public"):
-            allowed_paths.add("one/package.json")
+            allowed_paths.add(r"one/package.json")
 
-    return allowed_paths
+    return {re.compile(s) for s in allowed_paths}

--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -546,6 +546,8 @@ def get_allowed_github_files(owner: str, repo: str) -> set[re.Pattern]:
     }
 
     match (owner, repo):
+        case ("mozilla-firefox", "firefox") | ("mozilla-releng", "staging-firefox"):
+            allowed_paths.add(r"browser/extensions/[^/]+/manifest.json")
         case ("mozilla-extensions", _):
             allowed_paths.add(r"package.json")
         case ("mozilla-releng", "staging-xpi-public"):

--- a/frontend/src/components/vcs.js
+++ b/frontend/src/components/vcs.js
@@ -53,8 +53,14 @@ export async function getXpis(owner = null, repo = null, commit = null) {
   return req.data;
 }
 
-export async function getXPIVersion(owner, repo, commit, directory = null) {
-  let path = 'package.json';
+export async function getXPIVersion(
+  owner,
+  repo,
+  commit,
+  installType,
+  directory = null
+) {
+  let path = installType === 'mach' ? 'manifest.json' : 'package.json';
 
   if (directory) {
     path = `${directory}/${path}`;

--- a/frontend/src/views/NewXPIRelease/index.jsx
+++ b/frontend/src/views/NewXPIRelease/index.jsx
@@ -138,6 +138,7 @@ export default function NewXPIRelease() {
         selectedXpi.owner,
         selectedXpi.repo,
         selectedXpi.revision,
+        selectedXpi.install_type,
         selectedXpi.directory
       )
     ).data;


### PR DESCRIPTION
These use a `manifest.json` file rather than `package.json`.