### PR TITLE
Set `asyncio_default_fixture_loop_scope` to silence a bunch of warnings

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -108,9 +108,11 @@ requests = "*"
 [tool.poetry.group.tox.dependencies]
 tox = "*"
 
-
 [tool.poetry.group.dev.dependencies]
 flask-shell-ipython = "^0.5.1"
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Not setting this is deprecated (see
https://github.com/pytest-dev/pytest-asyncio/issues/924). We don't even use async fixtures AFAICT so it doesn't impact us but it still emits a lot of useless warnings