### PR TITLE
Remove reviewers from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,6 @@ updates:
         - "patch"
   commit-message:
     prefix: "chore(api)"
-  reviewers:
-    - "mozilla-releng/releng"
 - package-ecosystem: npm
   directory: "/frontend"
   versioning-strategy: increase-if-necessary


### PR DESCRIPTION
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/