### PR TITLE
Bug 1969826 - Assume the parameters.yml we're getting from taskcluster is UTF-8

### DIFF
--- a/api/src/shipit_api/admin/tasks.py
+++ b/api/src/shipit_api/admin/tasks.py
@@ -117,6 +117,7 @@ def fetch_artifact(task_id, artifact):
         url = queue.buildUrl("getLatestArtifact", task_id, artifact)
         q = requests.get(url)
         q.raise_for_status()
+        q.encoding = "utf-8"
         return yaml.safe_load(q.text)
     except requests.exceptions.HTTPError as e:
         if e.response.status_code == 404:


### PR DESCRIPTION
Right now, `getLatestArtifact` returns a file without specifying its encoding at all so requests defaults to decoding the body as `ISO-8859-1`. Taskgraph generates those files as UTF-8 which leads to discrepancies and eventually to exceptions if ever a commit message for example contains special characters outside of the ASCII range.

By telling requests that we know the body is going to be UTF-8, it's able to decode it properly and make the yaml library happy when there's such aforementioned characters.