### PR TITLE
Let the YAML library decode the content instead of assuming utf-8

### DIFF
--- a/api/src/shipit_api/admin/tasks.py
+++ b/api/src/shipit_api/admin/tasks.py
@@ -117,8 +117,7 @@ def fetch_artifact(task_id, artifact):
         url = queue.buildUrl("getLatestArtifact", task_id, artifact)
         q = requests.get(url)
         q.raise_for_status()
-        q.encoding = "utf-8"
-        return yaml.safe_load(q.text)
+        return yaml.safe_load(q.content)
     except requests.exceptions.HTTPError as e:
         if e.response.status_code == 404:
             raise ArtifactNotFound


### PR DESCRIPTION
This shouldn't change anything but it removes an assumption that the fetched artifacts will always be valid utf-8.