### PR TITLE
Add a way to start the worker by calling init.sh

### DIFF
--- a/api/docker.d/init.sh
+++ b/api/docker.d/init.sh
@@ -4,6 +4,11 @@ pushd `dirname $0` &>/dev/null
 MY_DIR=$(pwd)
 popd &>/dev/null
 
+if [ $1 == "worker" ]; then
+    poetry run flask worker
+    exit $?
+fi
+
 if [ $1 == "public" ]; then
     export FLASK_APP="shipit_api.public.flask:app"
 elif [ $1 == "admin" ]; then


### PR DESCRIPTION
Right now the deployment is hardcoded to running `poetry run flask worker` which is a bit of a pain if we want to switch to uv. By changing the entry point to use `init.sh` we can avoid breaking everything by merging this first to dev and prod, then changing the entrypoint in the deployment to use it. Then we're free to switch it to be using uv instead.