### PR TITLE
Fix the push-image kind docker image dependencies

### DIFF
--- a/taskcluster/kinds/push-image/kind.yml
+++ b/taskcluster/kinds/push-image/kind.yml
@@ -38,14 +38,14 @@ tasks:
     shipit-admin:
         description: "Push to shipit-admin repository."
         dependencies:
-            k8s-image: build-docker-image-shipit-admin
+            k8s-image: docker-image-shipit-admin
         worker:
             env:
                 DOCKER_REPO: docker.io/mozilla/releng-shipit-admin
     shipit-public:
         description: "Push to shipit-public repository."
         dependencies:
-            k8s-image: build-docker-image-shipit-public
+            k8s-image: docker-image-shipit-public
         worker:
             env:
                 DOCKER_REPO: docker.io/mozilla/releng-shipit-public


### PR DESCRIPTION
When taskgraph got updated in 0e50df631305a2002e934d9db81dfb762a55c99a, those dependencies should have been updated since
https://github.com/taskcluster/taskgraph/commit/70c73af7e8a16cc23a94f745cac138032039b6df changed the docker build task labels