### PR TITLE
Don't use refresh tokens with auth0

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -22,8 +22,6 @@ const App = () => {
           scope: config.AUTH0.scope,
         }}
         leeway={30}
-        useRefreshTokens
-        useRefreshTokensFallback
         cacheLocation="localstorage">
         <ThemeProvider theme={theme}>
           <Main />


### PR DESCRIPTION
Those get rejected because they require MFA again, which doesn't work very well when you try to do that silently leading to weird errors where the frontend thinks the user is authenticated but can't actually get a proper access token. They were not used either before this but I thought it was because of a misconfiguration of the previous library, not because it wouldn't work.