### PR TITLE
Change from react-time-ago to react-timeago

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,7 +67,7 @@
     "react-hot-loader": "4.13.0",
     "react-interval": "2.1.2",
     "react-router-dom": "5.3.3",
-    "react-time-ago": "6.2.4",
+    "react-timeago": "8.2.0",
     "taskcluster-lib-urls": "13.0.1"
   }
 }

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,9 +1,5 @@
 import React from 'react';
 import { render } from 'react-dom';
-import JavascriptTimeAgo from 'javascript-time-ago';
-import en from 'javascript-time-ago/locale/en';
 import App from './App';
-
-JavascriptTimeAgo.addLocale(en);
 
 render(<App />, document.getElementById('root'));

--- a/frontend/src/views/NewRelease/index.jsx
+++ b/frontend/src/views/NewRelease/index.jsx
@@ -2,7 +2,7 @@ import { Auth0Context } from '@auth0/auth0-react';
 import 'date-fns';
 import React, { useState, useContext } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
-import ReactTimeAgo from 'react-time-ago';
+import TimeAgo from 'react-timeago';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import Collapse from '@material-ui/core/Collapse';
@@ -231,7 +231,7 @@ export default function NewRelease() {
           m={1}
           className={classes.lessImportantData}
           key={branch.branch}>
-          updated <ReactTimeAgo date={branch.date} />
+          updated <TimeAgo date={branch.date} />
         </Box>
       );
     }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5779,13 +5779,6 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-javascript-time-ago@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/javascript-time-ago/-/javascript-time-ago-2.3.3.tgz#eb438bf159cc919b4123881241314fc962aae3f7"
-  integrity sha512-T4aOCWRQPWv5wsOBiiktKxu1Zd0deIHK2ymKg8XO+MEFZKnZklBOHCXrKbEWPD2Qk2V+ekfmX976r+W1+3dWsw==
-  dependencies:
-    relative-time-format "^1.0.5"
-
 jest-changed-files@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-26.6.2.tgz#f6198479e1cc66f22f9ae1e22acaa0b429c042d0"
@@ -7608,13 +7601,6 @@ qs@~6.5.2:
   resolved "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-raf@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz"
-  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
-  dependencies:
-    performance-now "^2.1.0"
-
 ramda@^0.26.1:
   version "0.26.1"
   resolved "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz"
@@ -7775,14 +7761,10 @@ react-side-effect@^2.1.0:
   resolved "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.0.tgz"
   integrity sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg==
 
-react-time-ago@6.2.4:
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/react-time-ago/-/react-time-ago-6.2.4.tgz#8ce678d2d776af94ff0dc0346c6ab3db65166bf4"
-  integrity sha512-pGFXSJGcn+QQTS42DqBkARX7J/wpFTKEIjVM4UCD1cpKeHFtxmg2Nepehr8vY21j4eyfUMZMcRwUi6pBRcq3Mg==
-  dependencies:
-    javascript-time-ago "^2.3.3"
-    prop-types "^15.7.2"
-    raf "^3.4.1"
+react-timeago@8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/react-timeago/-/react-timeago-8.2.0.tgz#a6c9c81f1ed8565f87d297d012c467944a0176be"
+  integrity sha512-RWDlG3Jj+iwv+yNEDweA/Qk1mxE8i/Oc4oW8Irp29ZfBp+eNpqqYPMLPYQJyfRMJcGB8CmWkEGMYhB4fW8eZlQ==
 
 react-transition-group@^4.0.0, react-transition-group@^4.4.0:
   version "4.4.1"
@@ -7984,11 +7966,6 @@ relateurl@0.2.x, relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
-
-relative-time-format@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.npmjs.org/relative-time-format/-/relative-time-format-1.0.5.tgz"
-  integrity sha512-MAgx/YKcUQYJpIaWcfetPstElnWf26JxVis4PirdwVrrymFdbxyCSm6yENpfB1YuwFbtHSHksN3aBajVNxk10Q==
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
I was looking at updating the former and while searching I found the latter which is pretty much as used but is way leaner, since the usage we make of this library is very minimal, we might as well.