### PR TITLE
feat: allow phase skipping for android on Try and Beta

### DIFF
--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -531,6 +531,10 @@ ALLOW_PHASE_SKIPPING = {
         "try": True,
         "beta": True,
     },
+    "firefox-android": {
+        "try": True,
+        "beta": True,
+    },
     "app-services": {
         "default": True,
     },


### PR DESCRIPTION
This makes it consistent with desktop product behaviour, and most notably allows for quicker test cycles on Try.