### PR TITLE
Replace clipboard-copy with native javascript

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,6 @@
     "babel-loader": "10.0.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "clean-webpack-plugin": "3.0.0",
-    "clipboard-copy": "^4.0.1",
     "css-loader": "3.6.0",
     "date-fns": "2.28.0",
     "eslint-config-airbnb": "18.2.0",

--- a/frontend/src/components/Dashboard/UserMenu.jsx
+++ b/frontend/src/components/Dashboard/UserMenu.jsx
@@ -7,7 +7,6 @@ import MenuItem from '@material-ui/core/MenuItem';
 import IconButton from '@material-ui/core/IconButton';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import ContentCopyIcon from 'mdi-react/ContentCopyIcon';
-import copy from 'clipboard-copy';
 import Button from '../Button';
 
 const useStyles = makeStyles(theme => ({
@@ -34,7 +33,7 @@ function UserMenu(props) {
   const handleCopyAccessToken = async () => {
     const accessToken = await auth0.getAccessTokenSilently();
 
-    copy(accessToken);
+    navigator.clipboard.writeText(accessToken);
     handleMenuClose();
   };
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3143,11 +3143,6 @@ clean-webpack-plugin@3.0.0:
     "@types/webpack" "^4.4.31"
     del "^4.1.1"
 
-clipboard-copy@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/clipboard-copy/-/clipboard-copy-4.0.1.tgz#326ef9726d4ffe72d9a82a7bbe19379de692017d"
-  integrity sha512-wOlqdqziE/NNTUJsfSgXmBMIrYmfd5V0HCGsR8uAKHcg+h9NENWINcfRjtWGU77wDHC8B8ijV4hMTGYbrKovng==
-
 cliui@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz"


### PR DESCRIPTION
I don't think we need to support firefox < 63 or IE11... Pulling in a library for this is just unnecessary