### PR TITLE
Add missing await on clipboard access

### DIFF
--- a/frontend/src/components/Dashboard/UserMenu.jsx
+++ b/frontend/src/components/Dashboard/UserMenu.jsx
@@ -33,7 +33,7 @@ function UserMenu(props) {
   const handleCopyAccessToken = async () => {
     const accessToken = await auth0.getAccessTokenSilently();
 
-    navigator.clipboard.writeText(accessToken);
+    await navigator.clipboard.writeText(accessToken);
     handleMenuClose();
   };
 


### PR DESCRIPTION
It was missing even before I switched it to native javascript but is still working 🤷 Let's do the right thing and add the missing await anyway, just in case