### PR TITLE
Appease yarn complaints about missing a dependency on babel/core

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
   "comment": "@date-io/date-fns is pinned because of https://github.com/mui-org/material-ui-pickers/issues/1440",
   "dependencies": {
     "@auth0/auth0-react": "^2.3.0",
+    "@babel/core": "^7.0.0",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/preset-env": "7.28.0",
     "@babel/preset-react": "7.27.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -54,7 +54,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.28.0.tgz#9fc6fd58c2a6a15243cd13983224968392070790"
   integrity sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==
 
-"@babel/core@^7.23.9", "@babel/core@^7.27.4":
+"@babel/core@^7.0.0", "@babel/core@^7.23.9", "@babel/core@^7.27.4":
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.28.0.tgz#55dad808d5bf3445a108eefc88ea3fdf034749a4"
   integrity sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==


### PR DESCRIPTION
Without this it complains about `warning "@babel/preset-env > ... unmet peer dependency "@babel/core@^7.0.0".` for all babel related deps which is annoying. Ultimately there's no change in behavior, and I don't even understand why this is necessary as those dependency have a dependency on babel themselves but it doesn't hurt and it cleans up the output of running `yarn`