### PR TITLE
Fix routes that require authentication

### DIFF
--- a/frontend/src/Main.jsx
+++ b/frontend/src/Main.jsx
@@ -3,7 +3,7 @@ import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
-import { BrowserRouter, Route, Routes } from 'react-router';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
 import Dashboard from './components/Dashboard';
 import ErrorPanel from './components/ErrorPanel';
 import { SHIPIT_API_URL, SHIPIT_PUBLIC_API_URL } from './config';
@@ -106,23 +106,24 @@ function Main() {
   return (
     <BrowserRouter>
       <Routes>
-        {routes.map(({ path, component, requiresAuth, exact, ...rest }) => (
-          <Route
-            key={path || 'not-found'}
-            path={path}
-            exact={exact}
-            Component={component}
-            render={() => (
-              <Suspense fallback={null}>
-                {requiresAuth && !user ? (
-                  <Redirect to="/" />
-                ) : (
-                  <component {...renderProps} {...rest} />
-                )}
-              </Suspense>
-            )}
-          />
-        ))}
+        {routes.map(
+          ({ path, component: Component, requiresAuth, exact, ...rest }) => (
+            <Route
+              key={path || 'not-found'}
+              path={path}
+              exact={exact}
+              element={
+                <>
+                  {requiresAuth && !user ? (
+                    <Navigate to="/" replace />
+                  ) : (
+                    <Component {...rest} />
+                  )}
+                </>
+              }
+            />
+          ),
+        )}
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -36,9 +36,11 @@ export default [
   {
     component: NewRelease,
     path: '/new',
+    requiresAuth: true,
   },
   {
     component: NewXPIRelease,
     path: '/newxpi',
+    requiresAuth: true,
   },
 ];


### PR DESCRIPTION
So this actually never worked, not even before the react updates as both `new` and `newxpi` weren't marked  as requiring authentication and they would just silently throw errors instead. With this, if you're unauthenticated it'll at least redirect you to the index which should show that you're not authed.

Also we can see how great of a language this is (/s) because `Redirect` doesn't even exist anymore and wasn't imported, neither was `Suspense`, and the `render` property doesn't exist on `Route` anymore... And yet, nothing complained about any part of it...