### PR TITLE
Re-enable code ownership for the frontend dependency files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 * @mozilla-releng/releng
-/frontend/package.json
-/frontend/yarn.lock


### PR DESCRIPTION
We don't have to ignore those anymore since we're all caught up :)