### PR TITLE
Remove the dependency on mdi-react and fix the android logo positioning

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,6 @@
     "@pmmmwh/react-refresh-webpack-plugin": "^0.6.1",
     "jest": "30.0.5",
     "jest-environment-jsdom": "30.0.5",
-    "mdi-react": "^9.4.0",
     "react-refresh": "^0.17.0",
     "webpack": "5.101.0",
     "webpack-cli": "6.0.1",

--- a/frontend/src/components/Dashboard/ReleasesMenu.jsx
+++ b/frontend/src/components/Dashboard/ReleasesMenu.jsx
@@ -1,6 +1,8 @@
 import { withAuth0 } from '@auth0/auth0-react';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import Button from '@mui/material/Button';
 import Collapse from '@mui/material/Collapse';
 import List from '@mui/material/List';
@@ -9,8 +11,6 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Menu from '@mui/material/Menu';
 import Typography from '@mui/material/Typography';
-import MenuDownIcon from 'mdi-react/MenuDownIcon';
-import RocketLaunchIcon from 'mdi-react/RocketLaunchIcon';
 import React, { Fragment, useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
 import Link from '../../utils/Link';
@@ -123,7 +123,7 @@ function ReleasesMenu({ disabled }) {
         aria-controls="user-menu"
         aria-label="user menu"
         startIcon={<RocketLaunchIcon />}
-        endIcon={<MenuDownIcon />}
+        endIcon={<ArrowDropDownIcon />}
         onClick={handleMenuOpen}
       >
         <Typography variant="h6" noWrap>

--- a/frontend/src/components/Dashboard/SettingsMenu.jsx
+++ b/frontend/src/components/Dashboard/SettingsMenu.jsx
@@ -1,4 +1,7 @@
 import { withAuth0 } from '@auth0/auth0-react';
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import LinkIcon from '@mui/icons-material/Link';
+import SettingsOutlineIcon from '@mui/icons-material/SettingsOutlined';
 import UpdateIcon from '@mui/icons-material/Update';
 import { ListItemIcon } from '@mui/material';
 import Button from '@mui/material/Button';
@@ -11,9 +14,6 @@ import ListItemButton from '@mui/material/ListItemButton';
 import ListItemText from '@mui/material/ListItemText';
 import Menu from '@mui/material/Menu';
 import Typography from '@mui/material/Typography';
-import LinkVariantIcon from 'mdi-react/LinkVariantIcon';
-import MenuDownIcon from 'mdi-react/MenuDownIcon';
-import SettingsOutlineIcon from 'mdi-react/SettingsOutlineIcon';
 import React, { Fragment, useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
 import useAction from '../../hooks/useAction';
@@ -66,7 +66,7 @@ function SettingsMenu({ auth0, disabled }) {
           aria-controls="user-menu"
           aria-label="user menu"
           startIcon={<SettingsOutlineIcon className={classes.icon} />}
-          endIcon={<MenuDownIcon className={classes.icon} />}
+          endIcon={<ArrowDropDownIcon className={classes.icon} />}
           onClick={handleMenuOpen}
         >
           <Typography variant="h6" noWrap>
@@ -100,7 +100,7 @@ function SettingsMenu({ auth0, disabled }) {
         >
           <ListItemButton>
             <ListItemIcon style={{ minWidth: '30px' }}>
-              <LinkVariantIcon />
+              <LinkIcon />
             </ListItemIcon>
             <ListItemText primary="Go to product details" />
           </ListItemButton>

--- a/frontend/src/components/Dashboard/UserMenu.jsx
+++ b/frontend/src/components/Dashboard/UserMenu.jsx
@@ -1,10 +1,10 @@
 import { withAuth0 } from '@auth0/auth0-react';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import ExitToAppIcon from '@mui/icons-material/ExitToApp';
 import Avatar from '@mui/material/Avatar';
 import IconButton from '@mui/material/IconButton';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
-import ContentCopyIcon from 'mdi-react/ContentCopyIcon';
 import React, { Fragment, useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
 import Button from '../Button';

--- a/frontend/src/components/PhaseProgress/index.jsx
+++ b/frontend/src/components/PhaseProgress/index.jsx
@@ -1,3 +1,4 @@
+import AndroidIcon from '@mui/icons-material/Android';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import LinkOutlinedIcon from '@mui/icons-material/LinkOutlined';
 import Box from '@mui/material/Box';
@@ -18,7 +19,6 @@ import StepButton from '@mui/material/StepButton';
 import StepLabel from '@mui/material/StepLabel';
 import Stepper from '@mui/material/Stepper';
 import Typography from '@mui/material/Typography';
-import AndroidIcon from 'mdi-react/AndroidIcon';
 import React, { useContext, useState } from 'react';
 import libUrls from 'taskcluster-lib-urls';
 import { makeStyles } from 'tss-react/mui';
@@ -281,22 +281,19 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
         )}
       </Stepper>
       <Dialog open={open} onClose={handleClose}>
-        <div style={{ position: 'relative' }}>
-          <div style={{ width: '50%', position: 'absolute' }}>
-            {release.name.toLowerCase().includes('android') && (
-              <AndroidIcon
-                style={{
-                  color: '#20ac5f',
-                  height: '3em',
-                  width: '3em',
-                  marginTop: '2em',
-                  marginLeft: '28.75em',
-                }}
-              />
-            )}
-          </div>
-        </div>
-        <DialogTitle>Schedule Phase</DialogTitle>
+        <DialogTitle>
+          Schedule Phase
+          {release.name.toLowerCase().includes('android') && (
+            <AndroidIcon
+              sx={{
+                color: '#20ac5f',
+                verticalAlign: 'middle',
+                fontSize: '1.5em',
+                marginLeft: '0.2em',
+              }}
+            />
+          )}
+        </DialogTitle>
         <DialogContent>
           {phase.signoffs && phase.signoffs.length > 0
             ? renderSignoffs()

--- a/frontend/src/components/ReleaseProgress/index.jsx
+++ b/frontend/src/components/ReleaseProgress/index.jsx
@@ -1,4 +1,6 @@
 import { Auth0Context } from '@auth0/auth0-react';
+import AndroidIcon from '@mui/icons-material/Android';
+import CancelIcon from '@mui/icons-material/Block';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
@@ -11,8 +13,6 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
-import AndroidIcon from 'mdi-react/AndroidIcon';
-import CancelIcon from 'mdi-react/CancelIcon';
 import React, { useContext, useState } from 'react';
 import { useLocation } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
@@ -198,21 +198,19 @@ export default function ReleaseProgress({
         <Box typography="caption" display="block">
           Created on {dateCreated} with {renderReleaseTitle(xpi, release)}
         </Box>
-        <div style={{ position: 'relative' }}>
-          <div style={{ width: '50%', position: 'absolute' }}>
+        <Box sx={{ position: 'relative' }}>
+          <Box sx={{ width: '50%', position: 'absolute' }}>
             {release.name.toLowerCase().includes('android') && (
               <AndroidIcon
-                style={{
+                sx={{
                   color: '#20ac5f',
-                  height: '2.5em',
-                  width: '2.5em',
-                  left: 0,
-                  marginTop: '1em',
+                  height: '1.5em',
+                  width: '1.5em',
                 }}
               />
             )}
-          </div>
-        </div>
+          </Box>
+        </Box>
         <PhaseProgress release={release} readOnly={!mutable} xpi={xpi} />
       </CardContent>
       <CardActions className={classes.cardActions}>

--- a/frontend/src/views/Releases/index.jsx
+++ b/frontend/src/views/Releases/index.jsx
@@ -1,7 +1,7 @@
+import RefreshIcon from '@mui/icons-material/Refresh';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
-import RefreshIcon from 'mdi-react/RefreshIcon';
 import React, { useEffect } from 'react';
 import { BrowserRouter, useLocation } from 'react-router';
 import {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4639,11 +4639,6 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
-mdi-react@^9.4.0:
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/mdi-react/-/mdi-react-9.4.0.tgz#b1f886681084fc85dabbcbc31b39b518f5030ced"
-  integrity sha512-3McdJimHT2CO+bSDGgJ1SSmU6HvXLEwLdfFi3M/nQT4aauvVxIbIGTCI8eOCcPtkyVyVuZRcCZ7Gw0oaGldYLw==
-
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"


### PR DESCRIPTION
This was providing material design icons which are already provided by `@mui/icons-material` so we had two versions of each icon, the mdi-react ones being very out of date.

It's worth noting that current main completely bork the android icon. I missed it in the MUI update but it's now overflowing the phase scheduling window

<img width="491" height="178" alt="image" src="https://github.com/user-attachments/assets/67c0d624-d503-4b9d-ac47-2f2cca837b07" />

And I also didn't think about it when I updated mdi-react which changed it to this new half cut robot. Unfortunately there's no more full bodied android logo except for the adb one so we're stuck with this half circle...

### Before

<img width="886" height="533" alt="image" src="https://github.com/user-attachments/assets/6cff34fe-6ec3-4643-91ae-846d692d5445" />
<img width="426" height="210" alt="image" src="https://github.com/user-attachments/assets/07cf9061-1e35-46f4-8606-b9536ee5b2ee" />

### After

<img width="998" height="746" alt="image" src="https://github.com/user-attachments/assets/c9b76dbe-ee15-46c8-a848-064e1be388f1" />

<img width="371" height="205" alt="image" src="https://github.com/user-attachments/assets/9e31e313-f956-49b1-a3b6-672a272af471" />
