### PR TITLE
Bug 1982606 - Return the version as JSON in `/versions/{product}/{channel}`

### DIFF
--- a/api/src/shipit_api/admin/api.yml
+++ b/api/src/shipit_api/admin/api.yml
@@ -652,7 +652,7 @@ paths:
         "200":
           description: The current version for the given product channel
           content:
-            text/plain:
+            application/json:
               schema:
                 type: string
                 example: "127.0a1"


### PR DESCRIPTION
At least one consumer (shipitscript) expects this to be JSON and not plain text as it uses `json.loads` on the return value. This fixes an unexpected change from the connexion 3 update in 71f06c67d48a02ae8b77a526cbeee31195cba5f3

Before:

```
> curl -kv  https://localhost:8015/versions/firefox/nightly

< content-type: text/plain; charset=utf-8
< content-length: 7
143.0a1
```

After:

```
> curl -kv  https://localhost:8015/versions/firefox/nightly

< Content-Type: application/json
< Content-Length: 10
"143.0a1"
```