### PR TITLE
Remove stray console.log that passed through and add lint rule for it

### DIFF
--- a/frontend/biome.jsonc
+++ b/frontend/biome.jsonc
@@ -24,6 +24,9 @@
       "complexity": {
         // All the ones it was giving were actually not useless...
         "noUselessFragments": "off"
+      },
+      "suspicious": {
+        "noConsole": "error"
       }
     },
     "domains": {

--- a/frontend/src/components/ErrorPanel/index.jsx
+++ b/frontend/src/components/ErrorPanel/index.jsx
@@ -3,7 +3,6 @@ import { string } from 'prop-types';
 import React, { useState } from 'react';
 
 export default function ErrorPanel({ error = null }) {
-  console.log('hi');
   const [currentError, setCurrentError] = useState(null);
   const [previousError, setPreviousError] = useState(null);
   const handleErrorClose = () => {


### PR DESCRIPTION
I'm not sure why this isn't a default lint rule but I don't see any reason why anyone should ever use console.log in this project. And if they do they can add an exception for it.