### PR TITLE
Bug 1982655 - Validate auth0 tokens on first page load

### DIFF
--- a/frontend/src/Main.jsx
+++ b/frontend/src/Main.jsx
@@ -66,18 +66,28 @@ function Main() {
   }, [getAccessTokenSilently, isLoading]);
 
   useEffect(() => {
+    const validateTokenOnFirstLoad = async () => {
+      if (user && !isLoading) {
+        await getAccessTokenSilently();
+      }
+    };
+
     if (!isReady && !isLoading) {
-      setReady(true);
+      validateTokenOnFirstLoad()
+        .catch(() => {})
+        .finally(() => setReady(true));
     }
-  }, [isLoading]);
+  }, [isLoading, user, getAccessTokenSilently, isReady]);
 
   const [backendStatus, checkBackendStatus] = useAction(() =>
     axios.get('/__heartbeat__'),
   );
 
   useEffect(() => {
-    checkBackendStatus();
-  }, []);
+    if (isReady) {
+      checkBackendStatus();
+    }
+  }, [isReady]);
 
   if (!isReady || backendStatus.loading) {
     return (


### PR DESCRIPTION
This fixes some annoyance regarding the auth0 authentication since we switched to auth0-react. Basically if your token is expired and auth0 can't refresh it for a reason, it used to only happen when authentication would actually be required to be valid (which happens quite late turns out as the frontend only checks for presence, not validity to prevent access to authed routes, joys of SPAs).

This means that you would start to create a release and suddenly hit a route that does require authentication (my example here is listing branches for a github repository when trying to create a firefox-ios release), which would then try to refresh the token before doing the request, fail, clear out the user object and redirect you to `/` as the router would realize you're not allowed on that page anymore leading to you losing 30s and having to log back in manually anyway.

Unfortunately I couldn't get anything better than this patch which won't be able to refresh your token properly all the time but at least it will log you out on the first page load instead of waiting until you're mid release creation.

The alternative would be to call loginWithPopup on failure, but because that popup wouldn't be coming from a user interaction it gets blocked by firefox. I think requiring the user to login is good enough and while it is annoying, it shouldn't happen that often. Heck, finding a way to reproduce this consistently involved me waiting for a weekend and cloning my fx profile over and over (thanks mozregression for making this painless...).