### PR TITLE
Fix /recent link not working unless the product would change

### DIFF
--- a/frontend/src/views/Releases/index.jsx
+++ b/frontend/src/views/Releases/index.jsx
@@ -70,7 +70,7 @@ export default function Releases({ recent = false, xpi = false }) {
 
       fetchReleases(productBranches);
     }
-  }, [group]);
+  }, [group, recent, xpi]);
 
   if (!(group in config.PRODUCTS)) {
     return (


### PR DESCRIPTION
The `useEffect` dependency array was missing `recent` and `xpi` parameters, causing it to not be called again and not fetch data when navigating to recent releases for the same product group that was already displayed.