### PR TITLE
Bug 1983817 - Move the CORS middleware before exceptions

### DIFF
--- a/api/src/backend_common/cors.py
+++ b/api/src/backend_common/cors.py
@@ -13,7 +13,7 @@ def init_app(app: connexion.App):
     origins = origins.split(" ")
     app.add_middleware(
         CORSMiddleware,
-        MiddlewarePosition.BEFORE_ROUTING,
+        MiddlewarePosition.BEFORE_EXCEPTION,
         allow_origins=origins,
         allow_methods=["*"],
         allow_headers=["authorization"],


### PR DESCRIPTION
The main issue with errors not being displayed is because those came from `flask.abort` which made routes raise `HttpException`s, which would be intercepted by the ASGI Exception middleware and not forwarded to the CORS one leading to those responses having the right info in them but not the right headers so the frontend wouldn't be able to read them, leading to network errors.

BEFORE_EXCEPTION is the recommended position in the documentation https://connexion.readthedocs.io/en/latest/cookbook.html#cors