### PR TITLE
Close the dashboard menu when the location changes

### DIFF
--- a/frontend/src/components/Dashboard/DashboardMenu.jsx
+++ b/frontend/src/components/Dashboard/DashboardMenu.jsx
@@ -3,7 +3,8 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import Button from '@mui/material/Button';
 import Menu from '@mui/material/Menu';
 import Typography from '@mui/material/Typography';
-import React, { Fragment, useState } from 'react';
+import React, { Fragment, useEffect, useState } from 'react';
+import { useLocation } from 'react-router';
 import { makeStyles } from 'tss-react/mui';
 
 const useStyles = makeStyles()(() => ({
@@ -31,9 +32,14 @@ function DashboardMenu({
   auth0,
 }) {
   const { classes } = useStyles();
+  const location = useLocation();
   const [anchorEl, setAnchorEl] = useState(null);
   const handleMenuOpen = (e) => setAnchorEl(e.currentTarget);
   const handleMenuClose = () => setAnchorEl(null);
+
+  useEffect(() => {
+    setAnchorEl(null);
+  }, [location]);
 
   if (!auth0.user || disabled) {
     return '';


### PR DESCRIPTION
Without this, the dashboard menu would stay open if you tried for example to click on Firefox->new, then on Thunderbird->new. While it's not the end of the world, this is an easy fix/win


This a followup to #1775 