### PR TITLE
Don't try to massage the `to` prop in `Link`

### DIFF
--- a/frontend/src/utils/Link.jsx
+++ b/frontend/src/utils/Link.jsx
@@ -10,8 +10,7 @@ import matchRoutes from './matchRoutes';
  * with pre-fetching capabilities.
  */
 export default function Link({ viewName, nav = false, to, ...props }) {
-  const path = typeof to === 'string' ? to : to.pathname;
-  const isPathAbsolute = isAbsolute(path);
+  const isPathAbsolute = isAbsolute(to);
   const Component = nav ? NavLink : RouterLink;
   const [prefetchFlag, setPrefetchFlag] = useState(false);
 
@@ -21,7 +20,7 @@ export default function Link({ viewName, nav = false, to, ...props }) {
     }
 
     if (!isPathAbsolute) {
-      const matchingRoutes = matchRoutes(path, routes);
+      const matchingRoutes = matchRoutes(to, routes);
 
       matchingRoutes.forEach(({ component }) => {
         component.preload();


### PR DESCRIPTION
I just fixed an issue in balrog that was hidden by said massaging (https://github.com/mozilla-releng/balrog/issues/3547). This is not even used at all in here because we're always passing a string to `to` and not using any `state`. But let's not keep a footgun for no reason