### PR TITLE
Force close the db session after every test involving the app fixture

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -56,6 +56,7 @@ def app(global_app):
         yield global_app
     finally:
         global_app.app.db.drop_all()
+        global_app.app.db.session.close()
 
 
 def mock_generate_phases(release):


### PR DESCRIPTION
If we don't do that and subsequent tests try to create objects in the same table, we get warnings because the session object will be reused and complain about rows not having a unique identity:

```
Identity map already had an identity for (<class'shipit_api.common.models.MergeAutomation'>, (1,), None), replacing it with newly flushed object. Are there load operations occurring inside of an event handler within the flush?
```