### PR TITLE
Allow `manifest.json` file to be placed in an `extension/` folder (bug 1988533)

### DIFF
--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -552,7 +552,7 @@ def get_allowed_github_files(owner: str, repo: str) -> set[re.Pattern]:
 
     match (owner, repo):
         case ("mozilla-firefox", "firefox") | ("mozilla-releng", "staging-firefox"):
-            allowed_paths.add(r"browser/extensions/[^/]+/manifest.json")
+            allowed_paths.add(r"browser/extensions/[^/]+(?:/extension)?/manifest.json")
         case ("mozilla-extensions", _):
             allowed_paths.add(r"package.json")
         case ("mozilla-releng", "staging-xpi-public"):


### PR DESCRIPTION
Some built-in add-ons use an `extension/` folder to isolate the add-on files. This PR adds the ability to look up the manifest either in the root folder or in the `<root>/extension/` folder.