### PR TITLE
api: load phases eagerly when querying releases

### DIFF
--- a/.codespell-ignore-words.txt
+++ b/.codespell-ignore-words.txt
@@ -1,1 +1,2 @@
 connexion
+selectin

--- a/api/src/shipit_api/common/models.py
+++ b/api/src/shipit_api/common/models.py
@@ -137,7 +137,7 @@ class Release(db.Model, ReleaseBase):
     build_number = sa.Column(sa.Integer, nullable=False)
     release_eta = sa.Column(sa.DateTime)
     status = sa.Column(sa.String)  # TODO: move to Enum: shipped, abandoned, scheduled
-    phases = sqlalchemy.orm.relationship("Phase", order_by=Phase.id, back_populates="release")
+    phases = sqlalchemy.orm.relationship("Phase", order_by=Phase.id, back_populates="release", lazy="selectin")
     created = sa.Column(sa.DateTime, default=datetime.datetime.utcnow)
     completed = sa.Column(sa.DateTime)
 
@@ -224,7 +224,7 @@ class XPIRelease(db.Model, ReleaseBase):
     xpi_version = sa.Column(sa.String, nullable=False)
     revision = sa.Column(sa.String, nullable=False)
     status = sa.Column(sa.String)
-    phases = sqlalchemy.orm.relationship("XPIPhase", order_by=XPIPhase.id, back_populates="release")
+    phases = sqlalchemy.orm.relationship("XPIPhase", order_by=XPIPhase.id, back_populates="release", lazy="selectin")
     created = sa.Column(sa.DateTime, default=datetime.datetime.utcnow)
     completed = sa.Column(sa.DateTime)
 


### PR DESCRIPTION
We include phases in releases' json representation, and lazy loading means we run into the N plus one problem
(https://docs.sqlalchemy.org/en/20/glossary.html#term-N-plus-one-problem) when e.g. listing releases.

Before:
```
%timeit list_releases(product='firefox', branch='releases/mozilla-beta', status=['shipped'])
4.6 s ± 918 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

After:
```
%timeit list_releases(product='firefox', branch='releases/mozilla-beta', status=['shipped'])
243 ms ± 18.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```