### PR TITLE
Add `limit` param to `/xpi/releases` (bug 1989577)

### DIFF
--- a/api/src/shipit_api/admin/api.yml
+++ b/api/src/shipit_api/admin/api.yml
@@ -466,6 +466,10 @@ paths:
             type: array
             items:
               type: string
+        - name: limit
+          in: query
+          schema:
+            type: number
       responses:
         "200":
           description: A list of releases

--- a/api/src/shipit_api/admin/xpi.py
+++ b/api/src/shipit_api/admin/xpi.py
@@ -52,7 +52,7 @@ def add_release(body):
     return release.json, 201
 
 
-def list_releases(xpi_name=None, xpi_version=None, build_number=None, status=["scheduled"]):
+def list_releases(xpi_name=None, xpi_version=None, build_number=None, status=["scheduled"], limit=None):
     session = current_app.db.session
     releases = session.query(XPIRelease)
     if xpi_name:
@@ -64,6 +64,8 @@ def list_releases(xpi_name=None, xpi_version=None, build_number=None, status=["s
     elif build_number:
         raise BadRequest(description="Filtering by build_number without version is not supported.")
     releases = releases.filter(XPIRelease.status.in_(status))
+    if limit:
+        releases = releases.limit(limit)
     response = [r.json for r in releases.all()]
     # Add an xpiUrl for the completed promote phases within xpi releases.
     # The xpi's created during the release's promote phase are signed and

--- a/frontend/src/components/api.js
+++ b/frontend/src/components/api.js
@@ -114,10 +114,11 @@ export async function getXPIBuildNumbers(xpiName, xpiVersion) {
   return releases.map((release) => release.build_number);
 }
 
-export async function getShippedXPIReleases() {
+export async function getShippedXPIReleases(limit) {
   const releases = await getReleases(
     {
       status: 'shipped',
+      limit: limit,
     },
     '/xpi/releases',
     false,
@@ -127,9 +128,7 @@ export async function getShippedXPIReleases() {
 }
 
 export async function getRecentXPIReleases(limit = 4) {
-  const releases = await getShippedXPIReleases();
-
-  return releases.slice(0, limit);
+  return await getShippedXPIReleases(limit);
 }
 
 export async function guessBuildNumber(product, version) {


### PR DESCRIPTION
Restrict the releases we're looking at upfront in SQL instead of doing extra work that we then throw away in the frontend.