### PR TITLE
frontend: guard against null disabledProducts in Footer

### DIFF
--- a/frontend/src/views/Footer/index.jsx
+++ b/frontend/src/views/Footer/index.jsx
@@ -28,7 +28,7 @@ export default function Footer() {
   const init = async () => {
     const disabledProducts = await getDisabledProductsAction();
 
-    setDisabledProducts(disabledProducts.data);
+    setDisabledProducts(disabledProducts.data ?? {});
   };
 
   useEffect(() => {


### PR DESCRIPTION
When the disabled-products API call errors, useAction returns `{ data: null }`, which then propagated into state and caused "right-hand side of 'in' should be an object, got null" at render time. Default to an empty object so the `in` check stays valid.

This can happen e.g. on localdev if the self-signed cert for the public endpoint is rejected by the browser.