### PR TITLE
chore: adjust renovate cron to run twice a month

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>mozilla-releng/reps:renovate-preset.json5"
-  ]
+  ],
+  "schedule": ["* 2 1,15 * *"]
 }


### PR DESCRIPTION
I plan to make the template default to monthly, but for things like shipit that deploy bi-weekly, I want it to be more frequent.

So overwrite the schedule to be twice a month as there isn't a good way to express bi-weekly in cron syntax. I think it's ok that they will now run on arbitrary days in relation to the deploys. This fully de-couples bumping dependencies from releases, so it's one less thing to do on release days.