### PR TITLE
feat: add support for tracking nightly release metadata

### DIFF
--- a/api/src/backend_common/api.yml
+++ b/api/src/backend_common/api.yml
@@ -11,8 +11,101 @@ info:
     name: MPL 2.0
     url: https://www.mozilla.org/MPL/2.0/
   version: 1.0.0
+paths:
+  /nightly-release:
+    get:
+      summary: List nightly releases
+      operationId: shipit_api.public.api.list_nightly_releases
+      parameters:
+        - name: product
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: channel
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: version
+          in: query
+          schema:
+            type: string
+        - name: buildid
+          in: query
+          schema:
+            type: string
+        - name: after_buildid
+          in: query
+          description: >
+              Only return releases with buildid greater than this value. Feeding
+              the highest buildid returned by a query using this argument into a
+              new request as `after_buildid` will allow paging through entries
+              in an ascending fashion.
+          schema:
+            type: string
+        - name: before_buildid
+          in: query
+          description: >
+              Only return releases with buildid less than this value. Feeding
+              the lowest buildid returned by a query using this argument into a
+              new request as `before_buildid` will allow paging through entries
+              in a descending fashion.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Maximum number of releases to return.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 500
+            default: 500
+        - name: order
+          in: query
+          schema:
+            type: string
+            enum:
+              - desc
+              - asc
+            default: desc
+      responses:
+        "200":
+          description: A list of nightly releases
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NightlyRelease'
 components:
   schemas:
+    NightlyRelease:
+      type: object
+      required:
+        - product
+        - channel
+        - version
+        - buildid
+        - locales
+      properties:
+        product:
+          type: string
+          example: firefox
+        channel:
+          type: string
+          example: nightly
+        version:
+          type: string
+          example: 140.0a1
+        buildid:
+          type: string
+          example: "20260522093015"
+        locales:
+          type: array
+          items:
+            type: string
+            example: zh-TW
     ProductInput:
       # ProductInput handles the products we currently support on shipit
       type: string

--- a/api/src/cli_common/openapi_subset.py
+++ b/api/src/cli_common/openapi_subset.py
@@ -16,6 +16,7 @@ PUBLIC_API_SECTIONS = [
     "paths./releases/{name}.get",
     "paths./releases/{name}/{phase}.get",
     "paths./disabled-products.get",
+    "paths./nightly-release.get",
     "components.schemas.ProductInput",
     "components.schemas.ProductOutput",
     "components.schemas.Phase",
@@ -24,6 +25,7 @@ PUBLIC_API_SECTIONS = [
     "components.schemas.Signoffs",
     "components.schemas.Signoff",
     "components.schemas.DisableProduct",
+    "components.schemas.NightlyRelease",
 ]
 
 

--- a/api/src/shipit_api/admin/api.py
+++ b/api/src/shipit_api/admin/api.py
@@ -26,7 +26,7 @@ from shipit_api.admin.release import (
 )
 from shipit_api.admin.tasks import UnsupportedFlavor, cancel_action_task_group, find_decision_task_id, generate_phases, rendered_hook_payload
 from shipit_api.common.config import HG_PREFIX, PROJECT_NAME, PULSE_ROUTE_REBUILD_PRODUCT_DETAILS, SCOPE_PREFIX
-from shipit_api.common.models import DisabledProduct, Phase, Release, Signoff, Version, XPIRelease
+from shipit_api.common.models import DisabledProduct, NightlyRelease, Phase, Release, Signoff, Version, XPIRelease
 from shipit_api.public.api import get_disabled_products, list_releases
 
 logger = logging.getLogger(__name__)
@@ -421,6 +421,30 @@ def create_product_channel_version(product, channel, body):
             "product": new_version.product_name,
             "channel": new_version.product_channel,
         }, 201
+
+
+def add_nightly_release(body):
+    product = body["product"]
+    required_permission = f"{SCOPE_PREFIX}/add_release/{product}"
+    if not current_user.has_permissions(required_permission):
+        user_permissions = ", ".join(current_user.get_permissions())
+        abort(401, f"required permission: {required_permission}, user permissions: {user_permissions}")
+
+    session = current_app.db.session
+    nightly = NightlyRelease(
+        product=product,
+        channel=body["channel"],
+        version=body["version"],
+        buildid=body["buildid"],
+        locales=body["locales"],
+    )
+    try:
+        session.add(nightly)
+        session.commit()
+    except IntegrityError as e:
+        abort(400, str(e))
+
+    return "", 201
 
 
 def check_decision_task(body):

--- a/api/src/shipit_api/admin/api.yml
+++ b/api/src/shipit_api/admin/api.yml
@@ -825,6 +825,28 @@ paths:
         "409":
           description: Already submitted
           content: {}
+  /nightly-release:
+    # get handler is defined in backend_common
+    post:
+      summary: Add a new nightly release
+      operationId: shipit_api.admin.api.add_nightly_release
+      requestBody:
+        description: Nightly release object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NightlyRelease'
+        required: true
+      responses:
+        "201":
+          description: Nightly release added
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NightlyRelease'
+        "400":
+          description: Invalid input
+          content: {}
   /versions/{product}/{channel}:
     get:
       summary: Get the current version for the given product channel

--- a/api/src/shipit_api/common/models.py
+++ b/api/src/shipit_api/common/models.py
@@ -327,3 +327,24 @@ class Version(db.Model):
     product_channel = sa.Column(sa.String, nullable=False)
     current_version = sa.Column(sa.String, nullable=False)
     __table_args__ = (sa.UniqueConstraint("product_name", "product_channel", name="_product_name_channel_uc"),)
+
+
+class NightlyRelease(db.Model):
+    __tablename__ = "shipit_api_nightly_releases"
+    id = sa.Column(sa.Integer, primary_key=True)
+    product = sa.Column(sa.String, nullable=False)
+    channel = sa.Column(sa.String, nullable=False)
+    version = sa.Column(sa.String, nullable=False)
+    buildid = sa.Column(sa.String, nullable=False)
+    locales = sa.Column(sa.JSON, nullable=False)
+    __table_args__ = (sa.UniqueConstraint("product", "channel", "buildid", name="_nightly_release_uc"),)
+
+    @property
+    def json(self):
+        return {
+            "product": self.product,
+            "channel": self.channel,
+            "version": self.version,
+            "buildid": self.buildid,
+            "locales": self.locales,
+        }

--- a/api/src/shipit_api/migrations/versions/c7e2a5f8b9d3_add_nightly_release.py
+++ b/api/src/shipit_api/migrations/versions/c7e2a5f8b9d3_add_nightly_release.py
@@ -1,0 +1,34 @@
+"""Add nightly release
+
+Revision ID: c7e2a5f8b9d3
+Revises: bc175ac0c2c5
+Create Date: 2026-05-22 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c7e2a5f8b9d3"
+down_revision = "bc175ac0c2c5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "shipit_api_nightly_releases",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("product", sa.String(), nullable=False),
+        sa.Column("channel", sa.String(), nullable=False),
+        sa.Column("version", sa.String(), nullable=False),
+        sa.Column("buildid", sa.String(), nullable=False),
+        sa.Column("locales", sa.JSON(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("product", "channel", "buildid", name="_nightly_release_uc"),
+    )
+
+
+def downgrade():
+    op.drop_table("shipit_api_nightly_releases")

--- a/api/src/shipit_api/public/api.py
+++ b/api/src/shipit_api/public/api.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from flask import abort, current_app
 from werkzeug.exceptions import BadRequest
 
-from shipit_api.common.models import DisabledProduct, Phase, Release, XPIRelease
+from shipit_api.common.models import DisabledProduct, NightlyRelease, Phase, Release, XPIRelease
 from shipit_api.common.version import parse_version
 
 logger = logging.getLogger(__name__)
@@ -94,3 +94,23 @@ def get_disabled_products():
     for row in session.query(DisabledProduct).all():
         ret[row.product].append(row.branch)
     return ret
+
+
+def list_nightly_releases(product, channel, version=None, buildid=None, after_buildid=None, before_buildid=None, limit=500, order="desc"):
+    query = NightlyRelease.query.filter(NightlyRelease.product == product).filter(NightlyRelease.channel == channel)
+    if version:
+        query = query.filter(NightlyRelease.version == version)
+    if buildid:
+        query = query.filter(NightlyRelease.buildid == buildid)
+    if after_buildid:
+        query = query.filter(NightlyRelease.buildid > after_buildid)
+    if before_buildid:
+        query = query.filter(NightlyRelease.buildid < before_buildid)
+
+    if order == "asc":
+        query = query.order_by(NightlyRelease.buildid.asc())
+    else:
+        query = query.order_by(NightlyRelease.buildid.desc())
+
+    query = query.limit(limit)
+    return [r.json for r in query.all()]

--- a/api/tests/test_nightly_release.py
+++ b/api/tests/test_nightly_release.py
@@ -1,0 +1,281 @@
+from unittest.mock import Mock, patch
+
+from backend_common.db import db
+from shipit_api.common.models import NightlyRelease
+
+
+def test_list_nightly_releases_empty(app):
+    with app.test_client() as client:
+        response = client.get("/nightly-release?product=firefox&channel=nightly")
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+def test_list_nightly_releases(app):
+    n1 = NightlyRelease(product="firefox", channel="nightly", version="140.0a1", buildid="20260522093015", locales=["en-US", "de"])
+    n2 = NightlyRelease(product="firefox", channel="nightly", version="140.0a1", buildid="20260523093015", locales=["en-US", "de"])
+    db.session.add(n1)
+    db.session.add(n2)
+    with app.test_client() as client:
+        response = client.get("/nightly-release?product=firefox&channel=nightly")
+        assert response.status_code == 200
+        results = response.json()
+        assert len(results) == 2
+        assert sorted(r["buildid"] for r in results) == ["20260522093015", "20260523093015"]
+
+
+def test_list_nightly_releases_filter_by_buildid(app):
+    n1 = NightlyRelease(product="firefox", channel="nightly", version="140.0a1", buildid="20260522093015", locales=["en-US", "de"])
+    n2 = NightlyRelease(product="firefox", channel="nightly", version="140.0a1", buildid="20260523093015", locales=["en-US", "de"])
+    db.session.add(n1)
+    db.session.add(n2)
+
+    with app.test_client() as client:
+        response = client.get("/nightly-release?product=firefox&channel=nightly&buildid=20260523093015")
+        assert response.status_code == 200
+        results = response.json()
+        assert len(results) == 1
+        assert results[0]["buildid"] == "20260523093015"
+        assert results[0]["locales"] == ["en-US", "de"]
+
+
+def test_list_nightly_releases_filter_by_version(app):
+    n1 = NightlyRelease(product="firefox", channel="nightly", version="140.0a1", buildid="20260522093015", locales=["en-US", "de"])
+    n2 = NightlyRelease(product="firefox", channel="nightly", version="141.0a1", buildid="20260523093015", locales=["en-US", "de"])
+    db.session.add(n1)
+    db.session.add(n2)
+
+    with app.test_client() as client:
+        response = client.get("/nightly-release?product=firefox&channel=nightly&version=141.0a1")
+        assert response.status_code == 200
+        results = response.json()
+        assert len(results) == 1
+        assert results[0]["version"] == "141.0a1"
+
+
+def test_list_nightly_releases_no_match(app):
+    n1 = NightlyRelease(product="firefox", channel="nightly", version="140.0a1", buildid="20260522093015", locales=["en-US", "de"])
+    db.session.add(n1)
+
+    with app.test_client() as client:
+        response = client.get("/nightly-release?product=does-not-exist&channel=nightly")
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+def test_list_nightly_releases_missing_product_returns_400(app):
+    with app.test_client() as client:
+        response = client.get("/nightly-release?channel=nightly")
+        assert response.status_code == 400
+
+
+def test_list_nightly_releases_missing_channel_returns_400(app):
+    with app.test_client() as client:
+        response = client.get("/nightly-release?product=firefox")
+        assert response.status_code == 400
+
+
+@patch("shipit_api.admin.api.current_user", new_callable=lambda: Mock())
+def test_add_nightly_release(mock_user, app):
+    mock_user.has_permissions.return_value = True
+
+    with app.test_client() as client:
+        response = client.post(
+            "/nightly-release",
+            json={
+                "product": "firefox",
+                "channel": "nightly",
+                "version": "140.0a1",
+                "buildid": "20260522093015",
+                "locales": ["en-US", "de", "fr"],
+            },
+        )
+        assert response.status_code == 201
+
+
+@patch("shipit_api.admin.api.current_user", new_callable=lambda: Mock())
+def test_add_nightly_release_duplicate_buildid_returns_400(mock_user, app):
+    mock_user.has_permissions.return_value = True
+
+    n1 = NightlyRelease(product="firefox", channel="nightly", version="140.0a1", buildid="20260522093015", locales=["en-US", "de"])
+    db.session.add(n1)
+
+    with app.test_client() as client:
+        response = client.post(
+            "/nightly-release",
+            json={
+                "product": "firefox",
+                "channel": "nightly",
+                "version": "140.0a1",
+                "buildid": "20260522093015",
+                "locales": ["de"],
+            },
+        )
+        assert response.status_code == 400
+
+
+@patch("shipit_api.admin.api.current_user", new_callable=lambda: Mock())
+def test_add_nightly_release_permission_denied(mock_user, app):
+    mock_user.has_permissions.return_value = False
+    mock_user.get_permissions.return_value = ["some:other:permission"]
+
+    with app.test_client() as client:
+        response = client.post(
+            "/nightly-release",
+            json={
+                "product": "firefox",
+                "channel": "nightly",
+                "version": "140.0a1",
+                "buildid": "20260522093015",
+                "locales": ["en-US"],
+            },
+        )
+        assert response.status_code == 401
+        detail = response.json()["detail"]
+        assert "project:releng:services/shipit_api/add_release/firefox" in detail
+
+
+def test_list_nightly_releases_default_order_desc(app):
+    db.session.add(NightlyRelease(product="firefox", channel="nightly", version="140.0a1", buildid="20260522093015", locales=["en-US"]))
+    db.session.add(NightlyRelease(product="firefox", channel="nightly", version="140.0a1", buildid="20260523093015", locales=["en-US"]))
+    db.session.add(NightlyRelease(product="firefox", channel="nightly", version="141.0a1", buildid="20260524093015", locales=["en-US"]))
+
+    with app.test_client() as client:
+        response = client.get("/nightly-release?product=firefox&channel=nightly")
+        assert response.status_code == 200
+        results = response.json()
+        assert [r["buildid"] for r in results] == ["20260524093015", "20260523093015", "20260522093015"]
+
+
+def test_list_nightly_releases_order_asc(app):
+    db.session.add(NightlyRelease(product="firefox", channel="nightly", version="140.0a1", buildid="20260522093015", locales=["en-US"]))
+    db.session.add(NightlyRelease(product="firefox", channel="nightly", version="140.0a1", buildid="20260523093015", locales=["en-US"]))
+    db.session.add(NightlyRelease(product="firefox", channel="nightly", version="141.0a1", buildid="20260524093015", locales=["en-US"]))
+
+    with app.test_client() as client:
+        response = client.get("/nightly-release?product=firefox&channel=nightly&order=asc")
+        assert response.status_code == 200
+        results = response.json()
+        assert [r["buildid"] for r in results] == ["20260522093015", "20260523093015", "20260524093015"]
+
+
+def test_list_nightly_releases_filter_by_after_buildid(app):
+    for i in range(5):
+        db.session.add(
+            NightlyRelease(
+                product="firefox",
+                channel="nightly",
+                version="140.0a1",
+                buildid=f"2026052{i}093015",
+                locales=["en-US"],
+            )
+        )
+
+    with app.test_client() as client:
+        response = client.get("/nightly-release?product=firefox&channel=nightly&after_buildid=20260522093015")
+        assert response.status_code == 200
+        results = response.json()
+        assert [r["buildid"] for r in results] == ["20260524093015", "20260523093015"]
+
+
+def test_list_nightly_releases_filter_by_before_buildid(app):
+    for i in range(5):
+        db.session.add(
+            NightlyRelease(
+                product="firefox",
+                channel="nightly",
+                version="140.0a1",
+                buildid=f"2026052{i}093015",
+                locales=["en-US"],
+            )
+        )
+
+    with app.test_client() as client:
+        response = client.get("/nightly-release?product=firefox&channel=nightly&before_buildid=20260522093015")
+        assert response.status_code == 200
+        results = response.json()
+        assert [r["buildid"] for r in results] == ["20260521093015", "20260520093015"]
+
+
+def test_list_nightly_releases_paging_before_buildid(app):
+    for i in range(5):
+        db.session.add(
+            NightlyRelease(
+                product="firefox",
+                channel="nightly",
+                version="140.0a1",
+                buildid=f"2026052{i}093015",
+                locales=["en-US"],
+            )
+        )
+
+    with app.test_client() as client:
+        response = client.get("/nightly-release?product=firefox&channel=nightly&limit=2")
+        assert response.status_code == 200
+        page1 = response.json()
+        buildids = [r["buildid"] for r in page1]
+        assert buildids == ["20260524093015", "20260523093015"]
+
+        next_max = buildids[-1]
+        response = client.get(f"/nightly-release?product=firefox&channel=nightly&limit=2&before_buildid={next_max}")
+        assert response.status_code == 200
+        page2 = response.json()
+        buildids = [r["buildid"] for r in page2]
+        assert buildids == ["20260522093015", "20260521093015"]
+
+        next_max = buildids[-1]
+        response = client.get(f"/nightly-release?product=firefox&channel=nightly&limit=2&before_buildid={next_max}")
+        assert response.status_code == 200
+        page3 = response.json()
+        buildids = [r["buildid"] for r in page3]
+        assert buildids == ["20260520093015"]
+
+        next_max = buildids[-1]
+        response = client.get(f"/nightly-release?product=firefox&channel=nightly&limit=2&before_buildid={next_max}")
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+def test_list_nightly_releases_paging_after_buildid(app):
+    for i in range(5):
+        db.session.add(
+            NightlyRelease(
+                product="firefox",
+                channel="nightly",
+                version="140.0a1",
+                buildid=f"2026052{i}093015",
+                locales=["en-US"],
+            )
+        )
+
+    with app.test_client() as client:
+        response = client.get("/nightly-release?product=firefox&channel=nightly&limit=2&order=asc")
+        assert response.status_code == 200
+        page1 = response.json()
+        buildids = [r["buildid"] for r in page1]
+        assert buildids == ["20260520093015", "20260521093015"]
+
+        next_max = buildids[-1]
+        response = client.get(f"/nightly-release?product=firefox&channel=nightly&limit=2&order=asc&after_buildid={next_max}")
+        assert response.status_code == 200
+        page2 = response.json()
+        buildids = [r["buildid"] for r in page2]
+        assert buildids == ["20260522093015", "20260523093015"]
+
+        next_max = buildids[-1]
+        response = client.get(f"/nightly-release?product=firefox&channel=nightly&limit=2&order=asc&after_buildid={next_max}")
+        assert response.status_code == 200
+        page3 = response.json()
+        buildids = [r["buildid"] for r in page3]
+        assert buildids == ["20260524093015"]
+
+        next_max = buildids[-1]
+        response = client.get(f"/nightly-release?product=firefox&channel=nightly&limit=2&order=asc&after_buildid={next_max}")
+        assert response.status_code == 200
+        assert response.json() == []
+
+
+def test_list_nightly_releases_limit_above_max_rejected(app):
+    with app.test_client() as client:
+        response = client.get("/nightly-release?product=firefox&channel=nightly&limit=501")
+        assert response.status_code == 400


### PR DESCRIPTION
As part of https://bugzilla.mozilla.org/show_bug.cgi?id=2031045 I need a way to cheaply find the first version a locale shipped with. The solution I'm aiming at is making this data available in product-details. We already gather enough data as part of rebuilding it to make this data available for releases. We don't have it for nightlies. Let's put this data into Ship It, similar to how we're [already tracking current nightly version information](https://github.com/mozilla-releng/shipit/blob/fb4469b28650c6dbcb78e3758c181e5b82ea089a/api/src/shipit_api/common/models.py#L323). After this is landed we'll need to do a backfill of Nightly data by hand, and update it in automation (similar to how we [add current nightly version information](https://searchfox.org/firefox-main/source/taskcluster/kinds/release-update-product-channel-version/kind.yml)) before we can start putting this data in product details.

In theory, we could gather it by looking through VCS data or scraping archive -- in practice there's far too many nightlies for this to be practical (1,000s, if not 10,000s).

See also: https://bugzilla.mozilla.org/show_bug.cgi?id=2042596