### PR TITLE
feat: set user agent for requests to hg

### DIFF
--- a/api/src/shipit_api/admin/product_details.py
+++ b/api/src/shipit_api/admin/product_details.py
@@ -1184,7 +1184,8 @@ async def rebuild(
     ]
     logger.info("Getting locales from hg.mozilla.org for each release from database")
     # use limit_per_host=50 since hg.mozilla.org doesn't like too many connections
-    async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(limit_per_host=50), timeout=aiohttp.ClientTimeout(total=30)) as session:
+    headers = {"User-Agent": "ship-it"}
+    async with aiohttp.ClientSession(headers=headers, connector=aiohttp.TCPConnector(limit_per_host=50), timeout=aiohttp.ClientTimeout(total=30)) as session:
         # XXX: for some reason we didn't generate l10n for devedition in old_product_details
         # However, we do need to include devedition releases if there's no corresponding firefox
         # release, to populate firefox_primary_builds.json


### PR DESCRIPTION
This goes with https://github.com/mozilla/webservices-infra/pull/11219, where this user agent gets a higher rate limit. This really does nothing in production, where this is already unlimited because of the IPs the requests come from, but it fixes an issue I'm hitting in local dev where I can't effectively test product details rebuilds due to hg.m.o 406'ing me.