### PR TITLE
feat: build firefox_history_locales.json for the nightly channel

### DIFF
--- a/api/src/shipit_api/admin/product_details.py
+++ b/api/src/shipit_api/admin/product_details.py
@@ -8,6 +8,7 @@ import collections
 import functools
 import hashlib
 import io
+import itertools
 import json
 import logging
 import os
@@ -37,6 +38,8 @@ from shipit_api.admin.release import parse_version
 from shipit_api.common.product import Product, ProductCategory
 
 logger = logging.getLogger(__name__)
+
+NIGHTLY_RELEASES_BATCH_SIZE = 1000
 
 File = str
 ReleaseDetails = TypedDict(
@@ -305,12 +308,16 @@ def get_releases_from_db(db_session: sqlalchemy.orm.Session, breakpoint_version:
     return query.all()
 
 
-def get_nightly_releases_from_db(db_session: sqlalchemy.orm.Session, product: str, channel: str) -> typing.List[shipit_api.common.models.NightlyRelease]:
+def get_nightly_releases_from_db(db_session: sqlalchemy.orm.Session, product: str, channel: str) -> typing.Iterator[shipit_api.common.models.NightlyRelease]:
     NightlyRelease = shipit_api.common.models.NightlyRelease
     query = db_session.query(NightlyRelease)
     query = query.filter(NightlyRelease.product == product)
     query = query.filter(NightlyRelease.channel == channel)
-    return query.all()
+    # batching and ordering avoids loading all objects (which could be 10,000+) at once,
+    # and allows the callers to bail early if it finds all necessary information before
+    # iterating over all rows
+    query = query.order_by(NightlyRelease.buildid.desc())
+    return query.yield_per(NIGHTLY_RELEASES_BATCH_SIZE)
 
 
 def get_product_channel_version(db_session: sqlalchemy.orm.Session, product: str, channel: str):
@@ -1066,24 +1073,28 @@ def get_thunderbird_beta_builds() -> typing.Dict:
     return dict()
 
 
-def get_firefox_nightly_locales(nightly_releases: typing.List[shipit_api.common.models.NightlyRelease]) -> FirefoxLocales:
+def get_firefox_nightly_locales(nightly_releases: typing.Iterable[shipit_api.common.models.NightlyRelease]) -> FirefoxLocales:
     """Generate the first version each locale has been continuously available on
     for nightly releases.
     """
-    builds = sorted(nightly_releases, key=lambda nightly: nightly.buildid, reverse=True)
-    if not builds:
+    builds = iter(nightly_releases)
+    try:
+        latest_build = next(builds)
+    except StopIteration:
         return {}
+
     # locales not present in the latest build are ignored completely, as they do
     # not meet the definition of "continuously available"; make these easily
     # available
-    latest_build_locales = builds[0].locales
+    needed_locales = set(latest_build.locales)
     # en-US is part of nightly metadata, but not part of this file
-    latest_build_locales.remove("en-US")
+    if "en-US" in needed_locales:
+        needed_locales.remove("en-US")
 
     last_release: typing.Dict[str, shipit_api.common.models.NightlyRelease] = {}
     done: typing.Set[str] = set()
 
-    for build in builds:
+    for build in itertools.chain([latest_build], builds):
         # identify any locales that we've already seen, and are missing from the current
         # build being checked (ie: the next oldest build)
         for locale in last_release:
@@ -1096,10 +1107,15 @@ def get_firefox_nightly_locales(nightly_releases: typing.List[shipit_api.common.
         # and the latest build that have not already had their last continuous
         # release identified
         for locale in build.locales:
-            if locale in done or locale not in latest_build_locales:
+            if locale in done or locale not in needed_locales:
                 continue
 
             last_release[locale] = build
+
+        # once every locale of interest has had its oldest continuous release
+        # identified, no older build can change the result; stop fetching
+        if done == needed_locales:
+            break
 
     result: FirefoxLocales = {}
     for locale, build in last_release.items():

--- a/api/src/shipit_api/admin/product_details.py
+++ b/api/src/shipit_api/admin/product_details.py
@@ -25,6 +25,7 @@ import backoff
 import click
 import sqlalchemy
 import sqlalchemy.orm
+from deepmerge import merge_or_raise
 from mozilla_version.gecko import FirefoxVersion
 from mozilla_version.mobile import MobileVersion
 
@@ -107,11 +108,25 @@ ThunderbirdVersions = TypedDict(
         "THUNDERBIRD_ESR_NEXT": str,
     },
 )
+FirstRelease = TypedDict("FirstRelease", {"version": str, "buildid": str})
+LocaleFirstReleases = TypedDict("LocaleFirstReleases", {"first_release": typing.Dict[str, FirstRelease]})
+FirefoxLocales = typing.Dict[str, LocaleFirstReleases]
 IndexListing = str
 ProductDetails = typing.Dict[
     File,
     typing.Union[
-        Releases, ReleasesHistory, PrimaryBuilds, FirefoxVersions, MobileVersions, MobileDetails, Region, L10n, Languages, ThunderbirdVersions, IndexListing
+        Releases,
+        ReleasesHistory,
+        PrimaryBuilds,
+        FirefoxVersions,
+        MobileVersions,
+        MobileDetails,
+        Region,
+        L10n,
+        Languages,
+        ThunderbirdVersions,
+        FirefoxLocales,
+        IndexListing,
     ],
 ]
 Products = typing.List[Product]
@@ -287,6 +302,14 @@ def get_releases_from_db(db_session: sqlalchemy.orm.Session, breakpoint_version:
     # Using cast and split_part is postgresql specific
     query = query.filter(Release.status == "shipped")
     query = query.filter(sqlalchemy.cast(sqlalchemy.func.split_part(Release.version, ".", 1), sqlalchemy.Integer) >= breakpoint_version)
+    return query.all()
+
+
+def get_nightly_releases_from_db(db_session: sqlalchemy.orm.Session, product: str, channel: str) -> typing.List[shipit_api.common.models.NightlyRelease]:
+    NightlyRelease = shipit_api.common.models.NightlyRelease
+    query = db_session.query(NightlyRelease)
+    query = query.filter(NightlyRelease.product == product)
+    query = query.filter(NightlyRelease.channel == channel)
     return query.all()
 
 
@@ -1043,6 +1066,79 @@ def get_thunderbird_beta_builds() -> typing.Dict:
     return dict()
 
 
+def get_firefox_nightly_locales(nightly_releases: typing.List[shipit_api.common.models.NightlyRelease]) -> FirefoxLocales:
+    """Generate the first version each locale has been continuously available on
+    for nightly releases.
+    """
+    builds = sorted(nightly_releases, key=lambda nightly: nightly.buildid, reverse=True)
+    if not builds:
+        return {}
+    # locales not present in the latest build are ignored completely, as they do
+    # not meet the definition of "continuously available"; make these easily
+    # available
+    latest_build_locales = builds[0].locales
+    # en-US is part of nightly metadata, but not part of this file
+    latest_build_locales.remove("en-US")
+
+    last_release: typing.Dict[str, shipit_api.common.models.NightlyRelease] = {}
+    done: typing.Set[str] = set()
+
+    for build in builds:
+        # identify any locales that we've already seen, and are missing from the current
+        # build being checked (ie: the next oldest build)
+        for locale in last_release:
+            # locale has been seen before, but now goes missing; last_release already
+            # contains the oldest continuous release, mark it as done
+            if locale not in build.locales:
+                done.add(locale)
+
+        # update last_release for all locales present in the current build
+        # and the latest build that have not already had their last continuous
+        # release identified
+        for locale in build.locales:
+            if locale in done or locale not in latest_build_locales:
+                continue
+
+            last_release[locale] = build
+
+    result: FirefoxLocales = {}
+    for locale, build in last_release.items():
+        result[locale] = {
+            "first_release": {
+                "nightly": {
+                    "version": build.version,
+                    "buildid": build.buildid,
+                }
+            }
+        }
+
+    return result
+
+
+def get_firefox_release_locales(releases: typing.List[shipit_api.common.models.Release]) -> FirefoxLocales:
+    """Generate the first version each locale has been continuously available
+    on for non-Nightly releases.
+    """
+    # TODO: implement me
+    return {}
+
+
+def get_firefox_locales(
+    releases: typing.List[shipit_api.common.models.Release], nightly_releases: typing.List[shipit_api.common.models.NightlyRelease]
+) -> FirefoxLocales:
+    """Generate the first version each locale has been continuously available on
+    for each Firefox channel (nightly, aurora, beta, release).
+
+    The data returned from this function is in the format required by
+    `firefox_history_locales.json`.
+    """
+
+    nightly_locales = get_firefox_nightly_locales(nightly_releases)
+    release_locales = get_firefox_release_locales(releases)
+
+    return merge_or_raise.merge(nightly_locales, release_locales)
+
+
 def sanity_check_firefox_builds(firefox_versions: FirefoxVersions, firefox_primary_builds: PrimaryBuilds, version_key: str, min_builds: int = 20) -> None:
     version = firefox_versions.get(version_key)
     if not version:
@@ -1159,6 +1255,10 @@ async def rebuild(
     firefox_nightly_version = get_product_channel_version(db_session, "firefox", "nightly")
     thunderbird_nightly_version = get_product_channel_version(db_session, "thunderbird", "nightly")
 
+    # get all firefox nightly builds (with their locales) for firefox_history_locales.json
+    logger.info("Getting firefox nightly releases from the database")
+    firefox_nightly_releases = get_nightly_releases_from_db(db_session, "firefox", "nightly")
+
     # Also fetch latest nightly builds with their L10N info
     nightly_builds = [
         shipit_api.common.models.Release(
@@ -1222,6 +1322,7 @@ async def rebuild(
             breakpoint_version, Product.FIREFOX, combined_releases, combined_l10n, old_product_details, firefox_nightly_version, thunderbird_nightly_version
         ),
         "firefox_versions.json": await get_firefox_versions(releases, firefox_nightly_version),
+        "firefox_history_locales.json": get_firefox_locales(releases, firefox_nightly_releases),
         "languages.json": get_languages(old_product_details),
         "mobile_android.json": get_releases(breakpoint_version, [Product.FENNEC, Product.FENIX, Product.FIREFOX_ANDROID], releases, old_product_details),
         "mobile_details.json": get_mobile_details(releases, firefox_nightly_version),

--- a/api/tests/test_product_details.py
+++ b/api/tests/test_product_details.py
@@ -295,10 +295,10 @@ async def test_rebuild(app, tmp_path):
 
 def test_get_firefox_locales():
     nightly_releases = [
-        NightlyRelease(product="firefox", channel="nightly", version="55.0a1", buildid="20170100000000", locales=["af", "de", "en-US"]),
-        NightlyRelease(product="firefox", channel="nightly", version="6.0a1", buildid="20110100000000", locales=["af", "de", "en-US"]),
         NightlyRelease(product="firefox", channel="nightly", version="56.0a1", buildid="20170200000000", locales=["af", "de", "en-US", "fr"]),
+        NightlyRelease(product="firefox", channel="nightly", version="55.0a1", buildid="20170100000000", locales=["af", "de", "en-US"]),
         NightlyRelease(product="firefox", channel="nightly", version="40.0a1", buildid="20150100000000", locales=["de", "en-US"]),
+        NightlyRelease(product="firefox", channel="nightly", version="6.0a1", buildid="20110100000000", locales=["af", "de", "en-US"]),
     ]
     releases = []
 
@@ -314,3 +314,28 @@ def test_get_firefox_locales():
 
     # en-US should not be included in this file, even though it's part of nightly release metadata
     assert "en-US" not in result
+
+
+def test_get_firefox_nightly_locales_stops_early():
+    # newest-first; "af" (the only locale of interest) is continuous in the two
+    # newest builds, then disappears in 58.0a1. At that point the result is fully
+    # determined and any older build is irrelevant, so it must never be fetched.
+    consumed = []
+
+    def build_stream():
+        builds = [
+            ("60.0a1", "20180300000000", ["af", "en-US"]),
+            ("59.0a1", "20180200000000", ["af", "en-US"]),
+            ("58.0a1", "20180100000000", ["en-US"]),
+            # older than the point where the result is determined; consuming this
+            # would mean we failed to stop early
+            ("57.0a1", "20170100000000", ["af", "en-US"]),
+        ]
+        for version, buildid, locales in builds:
+            consumed.append(buildid)
+            yield NightlyRelease(product="firefox", channel="nightly", version=version, buildid=buildid, locales=locales)
+
+    result = shipit_api.admin.product_details.get_firefox_nightly_locales(build_stream())
+
+    assert result["af"]["first_release"] == {"nightly": {"version": "59.0a1", "buildid": "20180200000000"}}
+    assert consumed == ["20180300000000", "20180200000000", "20180100000000"]

--- a/api/tests/test_product_details.py
+++ b/api/tests/test_product_details.py
@@ -16,7 +16,7 @@ from sqlalchemy import engine, event
 
 import shipit_api.admin.product_details
 from shipit_api.admin.product_details import fetch_l10n_data, rebuild
-from shipit_api.common.models import Release, Version
+from shipit_api.common.models import NightlyRelease, Release, Version
 
 
 # product_details uses a postgresql-specific "split_part" sql function
@@ -179,11 +179,21 @@ async def test_rebuild(app, tmp_path):
         status="shipped",
         partial_updates=None,
     )
+    # Two firefox nightly builds. "ach" is in both, so its first appearance is
+    # the earlier buildid; "zz" only appears in the newer one.
+    nightly_build_1 = NightlyRelease(
+        product="firefox", channel="nightly", version="134.0a1", buildid="20241101093000", locales=list(L10N_CHANGESETS.keys()) + ["en-US"]
+    )
+    nightly_build_2 = NightlyRelease(
+        product="firefox", channel="nightly", version="135.0a1", buildid="20241225093000", locales=list(L10N_CHANGESETS.keys()) + ["en-US", "zz"]
+    )
     app.app.db.session.add(fxnightly)
     app.app.db.session.add(tbnightly)
     app.app.db.session.add(deved)
     app.app.db.session.add(beta)
     app.app.db.session.add(release)
+    app.app.db.session.add(nightly_build_1)
+    app.app.db.session.add(nightly_build_2)
     app.app.db.session.commit()
     with (
         mock.patch("shipit_api.common.config.PRODUCT_DETAILS_DIR", tmp_path / "product-details"),
@@ -275,3 +285,32 @@ async def test_rebuild(app, tmp_path):
 
     assert not list(parent.glob("l10n/Devedition-*"))
     assert next(parent.glob("l10n/Firefox-134.0b8-*")).name == "Firefox-134.0b8-build1.json"
+
+    with (parent / "firefox_history_locales.json").open() as f:
+        locales = json.load(f)
+    assert locales["ach"]["first_release"] == {"nightly": {"version": "134.0a1", "buildid": "20241101093000"}}
+    # "zz" only appears in the newer build
+    assert locales["zz"]["first_release"] == {"nightly": {"version": "135.0a1", "buildid": "20241225093000"}}
+
+
+def test_get_firefox_locales():
+    nightly_releases = [
+        NightlyRelease(product="firefox", channel="nightly", version="55.0a1", buildid="20170100000000", locales=["af", "de", "en-US"]),
+        NightlyRelease(product="firefox", channel="nightly", version="6.0a1", buildid="20110100000000", locales=["af", "de", "en-US"]),
+        NightlyRelease(product="firefox", channel="nightly", version="56.0a1", buildid="20170200000000", locales=["af", "de", "en-US", "fr"]),
+        NightlyRelease(product="firefox", channel="nightly", version="40.0a1", buildid="20150100000000", locales=["de", "en-US"]),
+    ]
+    releases = []
+
+    result = shipit_api.admin.product_details.get_firefox_locales(releases, nightly_releases)
+
+    # "af" had a gap (present in 6.0a1, absent in 40.0a1, back from 55.0a1), so
+    # its first_release is the start of the most recent gap-free run, not 6.0a1.
+    assert result["af"]["first_release"] == {"nightly": {"version": "55.0a1", "buildid": "20170100000000"}}
+    # "de" was never dropped, so its run starts at the oldest build
+    assert result["de"]["first_release"] == {"nightly": {"version": "6.0a1", "buildid": "20110100000000"}}
+    # "fr" only appears in the newest build
+    assert result["fr"]["first_release"] == {"nightly": {"version": "56.0a1", "buildid": "20170200000000"}}
+
+    # en-US should not be included in this file, even though it's part of nightly release metadata
+    assert "en-US" not in result


### PR DESCRIPTION
This adds initial support for the new `firefox_history_locales.json` file described in https://bugzilla.mozilla.org/show_bug.cgi?id=2042596.

It's focused on just the Nightly channel initially; I plan to follow-up in fairly short order with support for other channels.

In order for this to work correctly in production I'll need to first backfill with metadata from each Nightly that added locales, and a recent Nightly. With that done, we'll end up with [this firefox_locales.json](https://gist.github.com/bhearsum/cff2f1bef5cd0d81b90b7e92a1f72c92). (I have that metadata and a script prepared locally to do this; I can share it if it's useful.)

We should also wait until [automatic nightly submission](https://phabricator.services.mozilla.com/D304523) is landed to merge this to ensure it updates correctly the next time a locale is added or removed.