### PR TITLE
Bug 1992478 - Remove data-leak-blocker from the list of system addons

### DIFF
--- a/api/src/shipit_api/common/config.py
+++ b/api/src/shipit_api/common/config.py
@@ -448,7 +448,6 @@ def _get_phases_definitions(phases):
 SUPPORTED_FLAVORS = _get_supported_flavors()
 
 SYSTEM_ADDONS = (
-    "data-leak-blocker",
     "newtab",
     "webcompat",
 )


### PR DESCRIPTION
This patch removes data-leak-blocker from the list of system addons (reverting the change previously applied from #1787) as the shipit part of [Bug 1992478](https://bugzilla.mozilla.org/show_bug.cgi?id=1992478) (which has removed it from the Firefox repository and currently riding Firefox 153 release train).