### PR TITLE
fix: don't allow empty locales to be submitted in nightly releases

### DIFF
--- a/api/src/shipit_api/admin/api.py
+++ b/api/src/shipit_api/admin/api.py
@@ -430,6 +430,9 @@ def add_nightly_release(body):
         user_permissions = ", ".join(current_user.get_permissions())
         abort(401, f"required permission: {required_permission}, user permissions: {user_permissions}")
 
+    if any(len(l) == 0 for l in body["locales"]):
+        abort(400, "entry in locales contains empty string")
+
     session = current_app.db.session
     nightly = NightlyRelease(
         product=product,

--- a/api/tests/test_nightly_release.py
+++ b/api/tests/test_nightly_release.py
@@ -115,6 +115,24 @@ def test_add_nightly_release_duplicate_buildid_returns_400(mock_user, app):
 
 
 @patch("shipit_api.admin.api.current_user", new_callable=lambda: Mock())
+def test_add_nightly_release_empty_locale_returns_400(mock_user, app):
+    mock_user.has_permissions.return_value = True
+
+    with app.test_client() as client:
+        response = client.post(
+            "/nightly-release",
+            json={
+                "product": "firefox",
+                "channel": "nightly",
+                "version": "140.0a1",
+                "buildid": "20260522093015",
+                "locales": ["de", ""],
+            },
+        )
+        assert response.status_code == 400
+
+
+@patch("shipit_api.admin.api.current_user", new_callable=lambda: Mock())
 def test_add_nightly_release_permission_denied(mock_user, app):
     mock_user.has_permissions.return_value = False
     mock_user.get_permissions.return_value = ["some:other:permission"]


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=2049378 discovered that this was allowed; let's reject them in the future.