### PR TITLE
fix: stop using management api auth0 audience

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,7 +27,6 @@ const App = () => {
           clientId={config.AUTH0.clientID}
           authorizationParams={{
             redirect_uri: config.AUTH0.redirectUri,
-            audience: config.AUTH0.audience,
             scope: config.AUTH0.scope,
           }}
           leeway={30}

--- a/frontend/src/configs/dev.js
+++ b/frontend/src/configs/dev.js
@@ -7,7 +7,6 @@ module.exports = {
     redirectUri: new URL('/login', window.location).href,
     scope: 'full-user-credentials openid profile email',
     responseType: 'token id_token',
-    audience: 'https://auth.mozilla.auth0.com/api/v2/',
   },
   PRODUCTS: {
     firefox: [

--- a/frontend/src/configs/local.js
+++ b/frontend/src/configs/local.js
@@ -7,7 +7,6 @@ module.exports = {
     redirectUri: new URL('/login', window.location).href,
     scope: 'full-user-credentials openid profile email',
     responseType: 'token id_token',
-    audience: 'https://auth.mozilla.auth0.com/api/v2/',
   },
   PRODUCTS: {
     firefox: [

--- a/frontend/src/configs/production.js
+++ b/frontend/src/configs/production.js
@@ -7,7 +7,6 @@ module.exports = {
     redirectUri: new URL('/login', window.location).href,
     scope: 'full-user-credentials openid profile email',
     responseType: 'token id_token',
-    audience: 'https://auth.mozilla.auth0.com/api/v2/',
   },
   PRODUCTS: {
     firefox: [


### PR DESCRIPTION
This looks like a longstanding mistake. Recently, logins started failing with errors about auth.mozilla.auth0.mozilla.com/api/v2 -- which is the management API. The IAM team confirmed that they recently locked this down more, which explains why this came up all of a sudden.

As far as I know, we don't make any use of the management API in Ship It (this is the API that's used to make changes to clients, etc.), so this should be safe.

I've tested this in Ship It Dev, where I was able to login again and cancel a release.