### PR TITLE
bug 2042596: add non-nightly channels to firefox_history_locales.json

### DIFF
--- a/api/src/shipit_api/admin/product_details.py
+++ b/api/src/shipit_api/admin/product_details.py
@@ -39,6 +39,7 @@ from shipit_api.common.product import Product, ProductCategory
 
 logger = logging.getLogger(__name__)
 
+AURORA_FIRST_VERSION = "54.0b11"
 NIGHTLY_RELEASES_BATCH_SIZE = 1000
 
 File = str
@@ -111,7 +112,7 @@ ThunderbirdVersions = TypedDict(
         "THUNDERBIRD_ESR_NEXT": str,
     },
 )
-FirstRelease = TypedDict("FirstRelease", {"version": str, "buildid": str})
+FirstRelease = TypedDict("FirstRelease", {"version": typing.Required[str], "buildid": str, "build_number": int}, total=False)
 LocaleFirstReleases = TypedDict("LocaleFirstReleases", {"first_release": typing.Dict[str, FirstRelease]})
 FirefoxLocales = typing.Dict[str, LocaleFirstReleases]
 IndexListing = str
@@ -173,6 +174,24 @@ def dt_to_ymd(d: datetime) -> str:
 
 def from_ymd_format(s: str) -> datetime:
     return from_format(s, YMD_DATE_FORMAT)
+
+
+def get_channel(version, product_category):
+    # some ESRs are marked with the "major" category; the only way to
+    # reliably detect them is to look at the version number. this must
+    # be done first to avoid eg: 140.0esr (a "major" release) returning
+    # "release" as the channel
+
+    if version.endswith("esr"):
+        return "esr"
+
+    match product_category:
+        case ProductCategory.DEVELOPMENT.value:
+            return "beta"
+        case ProductCategory.MAJOR.value | ProductCategory.STABILITY.value:
+            return "release"
+
+    raise Exception(f"Can't detect channel for version: {version}, category: {product_category}!")
 
 
 def create_index_listing_html(folder: pathlib.Path, items: typing.Set[pathlib.Path]) -> str:
@@ -1145,16 +1164,81 @@ def get_firefox_nightly_locales(nightly_releases: typing.Iterable[shipit_api.com
     return result
 
 
-def get_firefox_release_locales(releases: typing.List[shipit_api.common.models.Release]) -> FirefoxLocales:
+def get_firefox_release_locales(
+    firefox_releases: Releases, releases_l10n: dict[shipit_api.common.models.Release, ReleaseL10ns], old_product_details: ProductDetails
+) -> FirefoxLocales:
     """Generate the first version each locale has been continuously available
     on for non-Nightly releases.
     """
-    # TODO: implement me
-    return {}
+    channels = {}
+    # Combine release information with locales for each release
+    for product_with_version, details in firefox_releases["releases"].items():
+        version = product_with_version.split("-", 1)[1]
+        build_number = details["build_number"]
+        channel = get_channel(version, details["category"])
+
+        # Find the locale information
+        locales = None
+
+        # Older releases are only present in the old product details
+        l10n_file = f"1.0/l10n/{details['product'].capitalize()}-{version}-build{build_number}.json"
+        if l10n_file in old_product_details:
+            locales = set(old_product_details[l10n_file]["locales"].keys())
+        else:
+            # Newer (ie: ones that are only being published with this product-details rebuild)
+            # are only available in releases_l10n
+            for release, l10n_changesets in releases_l10n.items():
+                if release.product == details["product"] and release.version == version and release.build_number == details["build_number"]:
+                    locales = l10n_changesets.keys()
+
+        if locales is None:
+            # We don't have consistently available l10n information for versions < 40
+            # Don't error out unless we're missing data for newer versions
+            if parse_version(Product.FIREFOX, version).major_number < 40:
+                continue
+
+            raise Exception(f"Couldn't find l10n information for version: {version}")
+
+        release_metadata = {"version": version, "build_number": build_number}
+        channels.setdefault(channel, []).append((parse_version(Product.FIREFOX, version), release_metadata, locales))
+
+    # Find the first continuous release for each locale + channel (except `aurora`)
+    result: FirefoxLocales = {}
+    for channel, release_tuples in channels.items():
+        release_tuples.sort(key=lambda item: item[0], reverse=True)
+        ordered = [(release, locales) for _, release, locales in release_tuples]
+        for locale, release in first_continuous_releases(ordered).items():
+            if locale == "en-US":
+                continue
+
+            result.setdefault(locale, {"first_release": {}})["first_release"][channel] = release
+
+    # Populate `first_release` for the aurora channel, which is a snowflake.
+    # Prior to 54.0b11 it was more like a secondary Nightly channel of Firefox with
+    # a different locale configuration. Post 54.0b11 it turned into DevEdition,
+    # which always ships the same locales as Beta, is a separate product in Ship It,
+    # yet is a shipping channel of Firefox that must be included in the firefox locale metadata.
+    # To simplify things, we ignore the pre-54.0b11 state and simply treat it the same as Beta
+    # with a minimum version of 54.0b11.
+    aurora_floor = parse_version(Product.FIREFOX, AURORA_FIRST_VERSION)
+    for data in result.values():
+        beta = data["first_release"].get("beta")
+        if beta is None:
+            continue
+
+        if parse_version(Product.FIREFOX, beta["version"]) < aurora_floor:
+            data["first_release"]["aurora"] = {"version": AURORA_FIRST_VERSION, "build_number": 1}
+        else:
+            data["first_release"]["aurora"] = beta.copy()
+
+    return result
 
 
 def get_firefox_locales(
-    releases: typing.List[shipit_api.common.models.Release], nightly_releases: typing.List[shipit_api.common.models.NightlyRelease]
+    firefox_releases: Releases,
+    releases_l10n: dict[shipit_api.common.models.Release, ReleaseL10ns],
+    old_product_details: ProductDetails,
+    nightly_releases: typing.List[shipit_api.common.models.NightlyRelease],
 ) -> FirefoxLocales:
     """Generate the first version each locale has been continuously available on
     for each Firefox channel (nightly, aurora, beta, release).
@@ -1164,7 +1248,7 @@ def get_firefox_locales(
     """
 
     nightly_locales = get_firefox_nightly_locales(nightly_releases)
-    release_locales = get_firefox_release_locales(releases)
+    release_locales = get_firefox_release_locales(firefox_releases, releases_l10n, old_product_details)
 
     return merge_or_raise.merge(nightly_locales, release_locales)
 
@@ -1331,6 +1415,13 @@ async def rebuild(
     combined_l10n = releases_l10n.copy()
     combined_l10n.update(nightly_l10n)
 
+    # `firefox_releases` contains all data for both pre and post breakpoint versions
+    # this information is published in `firefox.json` and is also needed to create
+    # `firefox_history_locales.json`, so we pull it into an intermediate variable
+    # (unlike all of the other data below, which is only used for creation of a single
+    # file.)
+    firefox_releases = get_releases(breakpoint_version, [Product.FIREFOX], releases, old_product_details)
+
     # combine old and new data
     product_details: ProductDetails = {
         "all.json": get_releases(
@@ -1340,7 +1431,7 @@ async def rebuild(
             old_product_details,
         ),  # consider adding `android-components` at some point.
         "devedition.json": get_releases(breakpoint_version, [Product.DEVEDITION], releases, old_product_details),
-        "firefox.json": get_releases(breakpoint_version, [Product.FIREFOX], releases, old_product_details),
+        "firefox.json": firefox_releases,
         "firefox_history_development_releases.json": get_release_history(
             breakpoint_version, Product.FIREFOX, ProductCategory.DEVELOPMENT, releases, old_product_details
         ),
@@ -1352,7 +1443,7 @@ async def rebuild(
             breakpoint_version, Product.FIREFOX, combined_releases, combined_l10n, old_product_details, firefox_nightly_version, thunderbird_nightly_version
         ),
         "firefox_versions.json": await get_firefox_versions(releases, firefox_nightly_version),
-        "firefox_history_locales.json": get_firefox_locales(releases, firefox_nightly_releases),
+        "firefox_history_locales.json": get_firefox_locales(firefox_releases, releases_l10n, old_product_details, firefox_nightly_releases),
         "languages.json": get_languages(old_product_details),
         "mobile_android.json": get_releases(breakpoint_version, [Product.FENNEC, Product.FENIX, Product.FIREFOX_ANDROID], releases, old_product_details),
         "mobile_details.json": get_mobile_details(releases, firefox_nightly_version),

--- a/api/src/shipit_api/admin/product_details.py
+++ b/api/src/shipit_api/admin/product_details.py
@@ -1073,60 +1073,74 @@ def get_thunderbird_beta_builds() -> typing.Dict:
     return dict()
 
 
+def first_continuous_releases(releases: typing.Iterable[tuple[FirstRelease, list[str]]]) -> dict[str, FirstRelease]:
+    """Given an ordered (newest first) list of ``(release, locales)`` pairs, find the
+    oldest release each locale has been continuously available on.
+
+    Locales not present in the newest release are ignored, as they do not meet the
+    definition of "continuously available".
+    """
+    releases = iter(releases)
+    try:
+        latest_release = next(releases)
+    except StopIteration:
+        return {}
+
+    # locales not present in the latest release are ignored completely, as they do
+    # not meet the definition of "continuously available"; make these easily
+    # available
+    needed_locales = set(latest_release[1])
+
+    last_releases: typing.Dict[str, FirstRelease] = {}
+    done: typing.Set[str] = set()
+
+    for release, locales in itertools.chain([latest_release], releases):
+        # identify any locales that we've already seen, and are missing from the current
+        # release being checked (ie: the next oldest release)
+        for locale in last_releases:
+            # locale has been seen before, but now goes missing; last_releases already
+            # contains the oldest continuous release, mark it as done
+            if locale not in locales:
+                done.add(locale)
+
+        # update last_releases for all locales present in the current release
+        # and the latest release that have not already had their last continuous
+        # release identified
+        for locale in locales:
+            if locale in done or locale not in needed_locales:
+                continue
+
+            last_releases[locale] = release
+
+        # once every locale of interest has had its oldest continuous release
+        # identified, no older release can change the result; stop fetching
+        if done == needed_locales:
+            break
+
+    return last_releases
+
+
 def get_firefox_nightly_locales(nightly_releases: typing.Iterable[shipit_api.common.models.NightlyRelease]) -> FirefoxLocales:
     """Generate the first version each locale has been continuously available on
     for nightly releases.
     """
-    builds = iter(nightly_releases)
-    try:
-        latest_build = next(builds)
-    except StopIteration:
-        return {}
-
-    # locales not present in the latest build are ignored completely, as they do
-    # not meet the definition of "continuously available"; make these easily
-    # available
-    needed_locales = set(latest_build.locales)
-    # en-US is part of nightly metadata, but not part of this file
-    if "en-US" in needed_locales:
-        needed_locales.remove("en-US")
-
-    last_release: typing.Dict[str, shipit_api.common.models.NightlyRelease] = {}
-    done: typing.Set[str] = set()
-
-    for build in itertools.chain([latest_build], builds):
-        # identify any locales that we've already seen, and are missing from the current
-        # build being checked (ie: the next oldest build)
-        for locale in last_release:
-            # locale has been seen before, but now goes missing; last_release already
-            # contains the oldest continuous release, mark it as done
-            if locale not in build.locales:
-                done.add(locale)
-
-        # update last_release for all locales present in the current build
-        # and the latest build that have not already had their last continuous
-        # release identified
-        for locale in build.locales:
-            if locale in done or locale not in needed_locales:
-                continue
-
-            last_release[locale] = build
-
-        # once every locale of interest has had its oldest continuous release
-        # identified, no older build can change the result; stop fetching
-        if done == needed_locales:
-            break
-
     result: FirefoxLocales = {}
-    for locale, build in last_release.items():
-        result[locale] = {
-            "first_release": {
-                "nightly": {
-                    "version": build.version,
-                    "buildid": build.buildid,
-                }
-            }
-        }
+
+    def yield_releases() -> typing.Iterable[tuple[FirstRelease, list[str]]]:
+        # `first_continuous_releases` needs to work with these releases (which are NightlyRelease
+        # objects) and non-NightlyReleases (in order to implement `get_firefox_release_locales`);
+        # munge these releases into a generic format to accommodate this
+        for nr in nightly_releases:
+            # copy to avoid mutating the database object
+            locales = nr.locales.copy()
+            # en-US is included in the NightlyRelease metadata, but not in the locale list
+            # that we spit out; remove it upfront
+            if "en-US" in locales:
+                locales.remove("en-US")
+            yield ({"version": nr.version, "buildid": nr.buildid}, locales)
+
+    for locale, release in first_continuous_releases(yield_releases()).items():
+        result[locale] = {"first_release": {"nightly": release}}
 
     return result
 

--- a/api/tests/test_product_details.py
+++ b/api/tests/test_product_details.py
@@ -286,11 +286,54 @@ async def test_rebuild(app, tmp_path):
     assert not list(parent.glob("l10n/Devedition-*"))
     assert next(parent.glob("l10n/Firefox-134.0b8-*")).name == "Firefox-134.0b8-build1.json"
 
+    # we do some basic checking of this file; it is too large to do extensive checks of
+    # note that most of its contents come from the `testing` branch of the product-details repo
     with (parent / "firefox_history_locales.json").open() as f:
         locales = json.load(f)
-    assert locales["ach"]["first_release"] == {"nightly": {"version": "134.0a1", "buildid": "20241101093000"}}
-    # "zz" only appears in the newer build
+    assert locales["ach"]["first_release"] == {
+        "nightly": {"version": "134.0a1", "buildid": "20241101093000"},
+        "beta": {"version": "19.0b1", "build_number": 1},
+        "aurora": {"version": "54.0b11", "build_number": 1},
+        "release": {"version": "18.0", "build_number": 1},
+        "esr": {"version": "17.0.2esr", "build_number": 1},
+    }
+    assert locales["de"]["first_release"]["esr"] == {"version": "10.0.12esr", "build_number": 1}
+    # "zz" only appears in the newer nightly build, and in no release channel
     assert locales["zz"]["first_release"] == {"nightly": {"version": "135.0a1", "buildid": "20241225093000"}}
+
+
+def build_old_product_details(l10n_files):
+    return {f"1.0/l10n/{name}.json": {"locales": {locale: {"changeset": "default"} for locale in locales}} for name, locales in l10n_files.items()}
+
+
+def build_firefox_releases(entries):
+    return {
+        "releases": {
+            f"firefox-{version}": {
+                "category": category,
+                "product": "firefox",
+                "build_number": build_number,
+                "version": version.replace("esr", ""),
+            }
+            for version, category, build_number in entries
+        }
+    }
+
+
+def build_releases_l10n(entries):
+    return {
+        Release(
+            product="firefox",
+            version=version,
+            branch="",
+            revision="default",
+            build_number=build_number,
+            release_eta=None,
+            partial_updates=None,
+            status=None,
+        ): {locale: {"changeset": "default"} for locale in locales}
+        for version, build_number, locales in entries
+    }
 
 
 def test_get_firefox_locales():
@@ -300,20 +343,65 @@ def test_get_firefox_locales():
         NightlyRelease(product="firefox", channel="nightly", version="40.0a1", buildid="20150100000000", locales=["de", "en-US"]),
         NightlyRelease(product="firefox", channel="nightly", version="6.0a1", buildid="20110100000000", locales=["af", "de", "en-US"]),
     ]
-    releases = []
+    firefox_releases = build_firefox_releases(
+        [
+            ("110.0b1", "dev", 1),
+            ("134.0b8", "dev", 1),
+            ("134.0b9", "dev", 2),
+            ("133.0", "major", 2),
+            ("140.0esr", "major", 1),
+            ("140.2.0esr", "stability", 1),
+            ("128.0esr", "stability", 1),
+            ("52.9.0esr", "esr", 2),
+        ]
+    )
+    old_product_details = build_old_product_details(
+        {
+            "Firefox-110.0b1-build1": ["de"],
+            "Firefox-134.0b8-build1": ["af", "de"],
+            "Firefox-133.0-build2": ["af", "de", "fr"],
+            "Firefox-52.9.0esr-build2": ["de", "as"],
+        }
+    )
+    releases_l10n = build_releases_l10n(
+        [
+            ("134.0b9", 2, ["af", "de", "fr"]),
+            ("140.0esr", 1, ["de", "fr"]),
+            ("140.2.0esr", 1, ["de", "fr"]),
+            ("128.0esr", 1, ["de", "fr", "as"]),
+        ]
+    )
 
-    result = shipit_api.admin.product_details.get_firefox_locales(releases, nightly_releases)
+    result = shipit_api.admin.product_details.get_firefox_locales(firefox_releases, releases_l10n, old_product_details, nightly_releases)
 
-    # "af" had a gap (present in 6.0a1, absent in 40.0a1, back from 55.0a1), so
-    # its first_release is the start of the most recent gap-free run, not 6.0a1.
-    assert result["af"]["first_release"] == {"nightly": {"version": "55.0a1", "buildid": "20170100000000"}}
-    # "de" was never dropped, so its run starts at the oldest build
-    assert result["de"]["first_release"] == {"nightly": {"version": "6.0a1", "buildid": "20110100000000"}}
-    # "fr" only appears in the newest build
-    assert result["fr"]["first_release"] == {"nightly": {"version": "56.0a1", "buildid": "20170200000000"}}
-
+    # dropped after esr128
+    assert "as" not in result
     # en-US should not be included in this file, even though it's part of nightly release metadata
     assert "en-US" not in result
+    assert result["af"]["first_release"] == {
+        # "af" had a gap (present in 6.0a1, absent in 40.0a1, back from 55.0a1), so
+        # its first_release is the start of the most recent gap-free run, not 6.0a1.
+        "nightly": {"version": "55.0a1", "buildid": "20170100000000"},
+        "beta": {"version": "134.0b8", "build_number": 1},
+        "release": {"version": "133.0", "build_number": 2},
+        "aurora": {"version": "134.0b8", "build_number": 1},
+    }
+    assert result["de"]["first_release"] == {
+        # "de" was never dropped, so its run starts at the oldest build
+        "nightly": {"version": "6.0a1", "buildid": "20110100000000"},
+        "beta": {"version": "110.0b1", "build_number": 1},
+        "release": {"version": "133.0", "build_number": 2},
+        "aurora": {"version": "110.0b1", "build_number": 1},
+        "esr": {"version": "52.9.0esr", "build_number": 2},
+    }
+    assert result["fr"]["first_release"] == {
+        # "fr" only appears in the newest build
+        "nightly": {"version": "56.0a1", "buildid": "20170200000000"},
+        "beta": {"version": "134.0b9", "build_number": 2},
+        "release": {"version": "133.0", "build_number": 2},
+        "aurora": {"version": "134.0b9", "build_number": 2},
+        "esr": {"version": "128.0esr", "build_number": 1},
+    }
 
 
 def test_get_firefox_nightly_locales_stops_early():

--- a/api/tests/test_product_details.py
+++ b/api/tests/test_product_details.py
@@ -93,7 +93,7 @@ async def test_fetch_l10n_data():
 
 def mock_setup_working_copy(branch, url, secrets):
     subprocess.check_call(["git", "clone", "-n", url, str(shipit_api.common.config.PRODUCT_DETAILS_DIR)])
-    subprocess.check_call(["git", "checkout", "-b", branch, "906b7cd284728a2acec695ddcba9193b44d38982"], cwd=shipit_api.common.config.PRODUCT_DETAILS_DIR)
+    subprocess.check_call(["git", "checkout", "-b", branch, "26140d3435c386f36a94bd23ded5d08f8a41f080"], cwd=shipit_api.common.config.PRODUCT_DETAILS_DIR)
     subprocess.check_call(["git", "config", "user.email", "release-services+robot@mozilla.com"], cwd=shipit_api.common.config.PRODUCT_DETAILS_DIR)
     subprocess.check_call(["git", "config", "user.name", "Release Services Robot"], cwd=shipit_api.common.config.PRODUCT_DETAILS_DIR)
     subprocess.check_call(["git", "config", "commit.gpgsign", "false"], cwd=shipit_api.common.config.PRODUCT_DETAILS_DIR)


### PR DESCRIPTION
This is mostly straightforward with the exception how DevEdition/aurora is handled. As noted in the comments, I'm largely pretending that it didn't exist prior to 54.0b11. This means that the information for this channel is not _strictly_ accurate, but it allows me to sidestep a lot of complexity that is unlikely to benefit any real use case. I'm open to disagreement on this point.

https://gist.github.com/bhearsum/3ef0f84fd7f95f0cfb1a96c55b096dc3 contains a locally generated file from a relatively recent import from ship it production. https://github.com/mozilla-releng/product-details/blob/923f0c8fd053ad595218e24f2782364c18b7200e/public/1.0/firefox_history_locales.json is the latest version generated in dev. (Note that outside of Nightly, most locales don't exist because staging releases are typically run with a reduced locale set.)

This is a continuation of the work from https://github.com/mozilla-releng/shipit/pull/2009.