### PR TITLE
api: mark task/context {XPI,}Phase attributes as deferred (bug 2055898)

### DIFF
--- a/api/src/shipit_api/admin/api.py
+++ b/api/src/shipit_api/admin/api.py
@@ -10,6 +10,7 @@ import taskcluster_urls
 from flask import abort, current_app
 from flask_login import current_user
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import undefer_group
 from taskcluster.exceptions import TaskclusterRestFailure
 from werkzeug.exceptions import BadRequest
 
@@ -174,7 +175,15 @@ def do_schedule_phase(session, phase, additional_shipit_emails=()):
 def schedule_phase(name, phase):
     session = current_app.db.session
     phase = (
-        session.query(Phase).with_for_update().filter(Release.id == Phase.release_id).filter(Release.name == name).filter(Phase.name == phase).first_or_404()
+        session.query(Phase)
+        # do_schedule_phase reads task and context, which are deferred; undefer
+        # the group so they load with this row rather than in a follow-up query.
+        .options(undefer_group("task_context"))
+        .with_for_update()
+        .filter(Release.id == Phase.release_id)
+        .filter(Release.name == name)
+        .filter(Phase.name == phase)
+        .first_or_404()
     )
 
     # we must require scope which depends on product

--- a/api/src/shipit_api/admin/xpi.py
+++ b/api/src/shipit_api/admin/xpi.py
@@ -5,6 +5,7 @@ import taskcluster_urls
 from flask import abort, current_app
 from flask_login import current_user
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import undefer_group
 from taskcluster.exceptions import TaskclusterRestFailure
 from werkzeug.exceptions import BadRequest
 
@@ -93,7 +94,9 @@ def get_phase(name, phase):
 
 def schedule_phase(name, phase):
     session = current_app.db.session
-    phases = session.query(XPIPhase).filter(XPIRelease.id == XPIPhase.release_id).filter(XPIRelease.name == name).all()
+    # do_schedule_phase reads task and context (deferred); undefer the group so
+    # they load with these rows rather than in a follow-up query.
+    phases = session.query(XPIPhase).options(undefer_group("task_context")).filter(XPIRelease.id == XPIPhase.release_id).filter(XPIRelease.name == name).all()
     phase_to_schedule = list(filter(lambda _phase: _phase.name == phase, phases))
 
     # Get email for all signoffs from previous phases and phase scheduler

--- a/api/src/shipit_api/common/models.py
+++ b/api/src/shipit_api/common/models.py
@@ -88,8 +88,12 @@ class Phase(db.Model, PhaseBase):
     name = sa.Column(sa.String, nullable=False)
     submitted = sa.Column(sa.Boolean, nullable=False, default=False)
     task_id = sa.Column(sa.String, nullable=False)
-    task = sa.Column(sa.Text, nullable=False)
-    context = sa.Column(sa.Text, nullable=False)
+    # task and context hold the rendered action task and its params, which can
+    # be large. Defer them so that listing releases (which never reads them)
+    # doesn't load them into memory; group them so the scheduling code that does
+    # read them can pull both back at once. See bug 2055898.
+    task = sa.orm.deferred(sa.Column(sa.Text, nullable=False), group="task_context")
+    context = sa.orm.deferred(sa.Column(sa.Text, nullable=False), group="task_context")
     created = sa.Column(sa.DateTime, default=lambda: datetime.datetime.now(datetime.UTC))
     scheduled_at = sa.Column(sa.DateTime)
     scheduled_by = sa.Column(sa.String)
@@ -257,8 +261,9 @@ class XPIPhase(db.Model, PhaseBase):
     name = sa.Column(sa.String, nullable=False)
     submitted = sa.Column(sa.Boolean, nullable=False, default=False)
     task_id = sa.Column(sa.String, nullable=False)
-    task = sa.Column(sa.Text, nullable=False)
-    context = sa.Column(sa.Text, nullable=False)
+    # See the note on Phase.task/context above; same rationale (bug 2055898).
+    task = sa.orm.deferred(sa.Column(sa.Text, nullable=False), group="task_context")
+    context = sa.orm.deferred(sa.Column(sa.Text, nullable=False), group="task_context")
     created = sa.Column(sa.DateTime, default=lambda: datetime.datetime.now(datetime.UTC))
     scheduled_at = sa.Column(sa.DateTime)
     scheduled_by = sa.Column(sa.String)

--- a/api/tests/test_release.py
+++ b/api/tests/test_release.py
@@ -4,6 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
+from contextlib import contextmanager
 from contextlib import nullcontext as does_not_raise
 from unittest import mock
 
@@ -11,6 +12,7 @@ import pytest
 from mozilla_version.fenix import FenixVersion
 from mozilla_version.gecko import DeveditionVersion, FennecVersion, FirefoxVersion, ThunderbirdVersion
 from mozilla_version.mobile import MobileVersion
+from sqlalchemy import event
 
 import backend_common.auth
 import backend_common.taskcluster
@@ -18,6 +20,31 @@ from shipit_api.admin.api import get_signoff_emails
 from shipit_api.admin.release import bump_version, is_partner_attribution_enabled, is_partner_repacks_enabled, parse_version
 from shipit_api.common.models import Release, XPISignoff
 from shipit_api.common.product import Product
+from shipit_api.public.api import list_releases
+
+
+@contextmanager
+def capture_sql(session):
+    """Record every SQL statement executed on the session's engine."""
+    statements = []
+
+    def listener(conn, cursor, statement, parameters, context, executemany):
+        statements.append(statement)
+
+    engine = session.get_bind()
+    event.listen(engine, "after_cursor_execute", listener)
+    try:
+        yield statements
+    finally:
+        event.remove(engine, "after_cursor_execute", listener)
+
+
+def selects_phase_column(statements, column):
+    # A compiled entity SELECT lists a column as
+    # "shipit_api_phases.<column> AS shipit_api_phases_<column>". The " AS"
+    # suffix keeps "task" from also matching "task_id".
+    marker = f"shipit_api_phases.{column} AS"
+    return [s for s in statements if marker in s]
 
 
 @pytest.mark.parametrize(
@@ -172,13 +199,53 @@ def test_schedule_phase(app):
     with mock.patch(
         "shipit_api.admin.api.current_user", backend_common.auth.Auth0User("", {"email": "admin", "https://sso.mozilla.com/claim/groups": "releng"})
     ):
-        with app.test_client() as client:
-            response = client.put("/releases/Firefox-90.0-build1/promote")
-            assert response.status_code == 200
+        with capture_sql(session) as statements:
+            with app.test_client() as client:
+                response = client.put("/releases/Firefox-90.0-build1/promote")
+                assert response.status_code == 200
     assert [p.name for p in release.phases] == ["build", "promote", "ship"]
     assert [p.submitted for p in release.phases] == [True, True, False]
     assert [p.skipped for p in release.phases] == [True, False, False]
     assert [p.task_id for p in release.phases] == ["", "1", ""]
+
+    # The scheduling path fetches the phase with undefer_group("task_context"),
+    # so task/context are loaded inline with the entity (which also selects
+    # ``name``) rather than in a separate deferred-group query. Without the
+    # undefer, the entity fetch would omit task and a later query would load it,
+    # so no single statement would select both name and task.
+    assert any("shipit_api_phases.name AS" in s and "shipit_api_phases.task AS" in s for s in statements)
+
+
+def test_list_releases_does_not_load_task_context(app):
+    # Listing releases must not pull each phase's large ``task`` and ``context``
+    # columns from the database. Eagerly loading them across ~1400 releases at
+    # several phases each blew past the public app's memory limit and caused OOM
+    # restarts (bug 2055898); the columns are deferred so the list path skips
+    # them. This drives the real endpoint and asserts on the SQL it emits.
+    release = Release(
+        product="firefox",
+        version="90.0",
+        branch="mozilla-release",
+        revision="0" * 40,
+        build_number=1,
+        release_eta=None,
+        partial_updates=None,
+        status="scheduled",
+    )
+    release.phases = mock_generate_phases(release)
+    session = app.app.db.session
+    session.add(release)
+    session.commit()
+    session.expunge_all()
+
+    with capture_sql(session) as statements:
+        result = list_releases(status=["scheduled"])
+
+    assert [r["name"] for r in result] == ["Firefox-90.0-build1"]
+    # The endpoint did query the phases table, but never selected task/context.
+    assert any("shipit_api_phases" in s for s in statements)
+    assert not selects_phase_column(statements, "task")
+    assert not selects_phase_column(statements, "context")
 
 
 @mock.patch("shipit_api.admin.api.generate_phases", mock_generate_phases)


### PR DESCRIPTION
These attributes can be large, and are only used by schedule_phase. Avoid loading them by default so endpoints like list_releases don't need to carry around the extra data and run the container out of memory.