### PR TITLE
Convert MUI system props to sx to fix the v9 upgrade

### DIFF
--- a/frontend/src/components/PhaseProgress/index.jsx
+++ b/frontend/src/components/PhaseProgress/index.jsx
@@ -164,7 +164,7 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
                       <Typography
                         key={signoff.name}
                         variant="caption"
-                        display="block"
+                        sx={{ display: 'block' }}
                       >
                         {`${signoff.completed_by}, ${signoff.name}`}
                       </Typography>
@@ -175,10 +175,12 @@ export default function PhaseProgress({ release, readOnly, xpi }) {
             )}
             {!inProgress && phase.xpiUrl && (
               <Box
-                fontSize=".80rem"
-                fontWeight={500}
-                marginTop="1.6rem"
-                position="absolute"
+                sx={{
+                  fontSize: '.80rem',
+                  fontWeight: 500,
+                  marginTop: '1.6rem',
+                  position: 'absolute',
+                }}
               >
                 <Link href={phase.xpiUrl} underline="hover">
                   xpi package

--- a/frontend/src/components/ProductDisabler/index.jsx
+++ b/frontend/src/components/ProductDisabler/index.jsx
@@ -85,11 +85,11 @@ export default function ProductDisabler({
           </Typography>
           {productBranches.map((pb) => (
             <Typography
-              color="inherit"
               variant="subtitle1"
               noWrap
               className={classes.products}
               key={`${pb.product}-${pb.branch}`}
+              sx={{ color: 'inherit' }}
             >
               {pb.prettyProduct}: {pb.prettyBranch}
               {mutable ? (

--- a/frontend/src/components/ReleaseProgress/index.jsx
+++ b/frontend/src/components/ReleaseProgress/index.jsx
@@ -195,7 +195,7 @@ export default function ReleaseProgress({
         <Typography component="h3" variant="h6">
           {release.name}
         </Typography>
-        <Box typography="caption" display="block">
+        <Box sx={{ typography: 'caption', display: 'block' }}>
           Created on {dateCreated} with {renderReleaseTitle(xpi, release)}
         </Box>
         <Box sx={{ position: 'relative' }}>

--- a/frontend/src/components/Shared/MouseOverPopover.jsx
+++ b/frontend/src/components/Shared/MouseOverPopover.jsx
@@ -40,11 +40,7 @@ export default function MouseOverPopover({
         aria-haspopup="true"
         onMouseEnter={handlePopoverOpen}
         onMouseLeave={handlePopoverClose}
-        fontSize={fontSize}
-        fontWeight={fontWeight}
-        marginTop={marginTop}
-        marginLeft={marginLeft}
-        position={position}
+        sx={{ fontSize, fontWeight, marginTop, marginLeft, position }}
       >
         {text}
       </Box>

--- a/frontend/src/views/NewMergeAutomation/index.jsx
+++ b/frontend/src/views/NewMergeAutomation/index.jsx
@@ -174,7 +174,7 @@ export default function NewMergeAutomation() {
     }
 
     return (
-      <Box display="flex" gap={2}>
+      <Box sx={{ display: 'flex', gap: 2 }}>
         <InputLabel>Behavior</InputLabel>
         <Select
           sx={{ flexGrow: 1 }}
@@ -262,7 +262,7 @@ export default function NewMergeAutomation() {
           <Typography variant="body2" sx={{ fontWeight: 500 }}>
             {revisionInfo.commit_message}
           </Typography>
-          <Typography variant="body2" color="text.secondary">
+          <Typography variant="body2" sx={{ color: 'text.secondary' }}>
             {revisionInfo.commit_author}
           </Typography>
         </CommitInfoBox>

--- a/frontend/src/views/NewRelease/index.jsx
+++ b/frontend/src/views/NewRelease/index.jsx
@@ -345,7 +345,7 @@ export default function NewRelease() {
       label.push(
         <Box
           component="span"
-          m={1}
+          sx={{ m: 1 }}
           className={classes.lessImportantData}
           key={branch.branch}
         >
@@ -389,7 +389,7 @@ export default function NewRelease() {
 
   const renderRevisionInput = () => {
     return (
-      <Grid container alignItems="center">
+      <Grid container sx={{ alignItems: 'center' }}>
         <Autocomplete
           className={classes.formControl}
           freeSolo
@@ -458,7 +458,7 @@ export default function NewRelease() {
   const renderPartials = () => {
     if (selectedProduct) {
       return (
-        <Grid container alignItems="center">
+        <Grid container sx={{ alignItems: 'center' }}>
           <TextField
             label="Partial updates"
             disabled={!partialFieldEnabled}

--- a/frontend/src/views/NewXPIRelease/index.jsx
+++ b/frontend/src/views/NewXPIRelease/index.jsx
@@ -239,7 +239,7 @@ export default function NewXPIRelease() {
 
   const renderCreateReleaseButton = () => {
     return (
-      <Grid container alignItems="center">
+      <Grid container sx={{ alignItems: 'center' }}>
         <Button
           color="primary"
           variant="contained"

--- a/frontend/src/views/Releases/index.jsx
+++ b/frontend/src/views/Releases/index.jsx
@@ -91,10 +91,7 @@ export default function Releases({ recent = false, xpi = false }) {
         title={recent ? 'Recent Releases' : 'Pending Releases'}
       >
         <Box
-          display="flex"
-          justifyContent="right"
-          alignItems="right"
-          marginRight="1%"
+          sx={{ display: 'flex', justifyContent: 'right', marginRight: '1%' }}
         >
           <Button
             startIcon={<RefreshIcon />}


### PR DESCRIPTION
2d88b34364c3957ba86658973e32c21c04c96ead bumped MUI from v7 to v9. That migration dropped support for system props on `Box`, `Typography` and `Grid` so they were silently ignored, breaking layouting in subtle (and not so subtle) ways.

This commit changes those to `sx` which makes them useful again, fixing layout. Also dropped `alignItems` from the refresh button on the releases page because it was never a valid value and was ignored anyway.