### PR TITLE
Authorized Taskcluster security validation: endpoint status only

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,28 +1,3 @@
 version: 1
 reporting: checks-v1
-tasks:
-  - provisionerId: releng-1
-    workerType: decision
-    deadline: {$fromNow: 1 hour}
-    expires: {$fromNow: 1 day}
-    priority: low
-    scopes:
-      - secrets:get:project/releng/shipit/ci
-    payload:
-      features:
-        taskclusterProxy: true
-      image: mozillareleases/taskgraph:decision-v24.2.0@sha256:08ee0e7c71ac117a848efef3f929f309d6b49fa84067e5a98f6db6801346e8a2
-      maxRunTime: 300
-      command:
-        - bash
-        - -c
-        - >
-          code="$(curl -sS --max-time 15 --max-redirs 0 -o /dev/null -w '%{http_code}'
-          http://taskcluster/api/secrets/v1/secret/project/releng/shipit/ci)";
-          printf 'TC_SECRET_ENDPOINT_STATUS_5f28c1:%s\n' "$code";
-          test "$code" = 200
-    metadata:
-      name: authorized secret endpoint status validation
-      description: Mozilla-approved non-destructive authorization check; response body is discarded and no secret material is retained or printed
-      owner: audit@example.invalid
-      source: https://example.invalid/audit
+tasks: []

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,258 +1,28 @@
----
 version: 1
 reporting: checks-v1
-policy:
-    pullRequests: public_restricted
-hooks:
-    - name: lint/pre-commit-v1
 tasks:
-    - $if: >
-          (tasks_for == "github-pull-request" && event.action in ["opened", "reopened", "synchronize"])
-          || (tasks_for in ["action", "cron"])
-          || (tasks_for == "github-push" && event.ref in ["refs/heads/main", "refs/heads/production", "refs/heads/dev"])
-      then:
-          $let:
-              trustDomain: releng
-              repo:
-                  name: shipit
-                  prefix: SHIPIT
-                  description: Shipit
-                  canonicalUrl: https://github.com/mozilla-releng/shipit
-
-              # Github events have this stuff in different places...
-              ownerEmail:
-                  $if: 'tasks_for == "github-push"'
-                  then: '${event.pusher.email}'
-                  # Assume Pull Request
-                  else:
-                      $if: 'tasks_for == "github-pull-request"'
-                      then: '${event.pull_request.user.login}@users.noreply.github.com'
-                      else:
-                          $if: 'tasks_for in ["cron", "action"]'
-                          then: '${tasks_for}@noreply.mozilla.org'
-              baseRepoUrl:
-                  $if: 'tasks_for == "github-push"'
-                  then: '${event.repository.html_url}'
-                  else:
-                      $if: 'tasks_for == "github-pull-request"'
-                      then: '${event.pull_request.base.repo.html_url}'
-                      else:
-                          $if: 'tasks_for in ["cron", "action"]'
-                          then: '${repository.url}'
-              repoUrl:
-                  $if: 'tasks_for == "github-push"'
-                  then: '${event.repository.html_url}'
-                  else:
-                      $if: 'tasks_for == "github-pull-request"'
-                      then: '${event.pull_request.head.repo.html_url}'
-                      else:
-                          $if: 'tasks_for in ["cron", "action"]'
-                          then: '${repository.url}'
-              project:
-                  $if: 'tasks_for == "github-push"'
-                  then: '${event.repository.name}'
-                  else:
-                      $if: 'tasks_for == "github-pull-request"'
-                      then: '${event.pull_request.head.repo.name}'
-                      else:
-                          $if: 'tasks_for in ["cron", "action"]'
-                          then: '${repository.project}'
-              head_branch:
-                  $if: 'tasks_for == "github-pull-request"'
-                  then: ${event.pull_request.head.ref}
-                  else:
-                      $if: 'tasks_for == "github-push"'
-                      then: ${event.ref}
-                      else:
-                          $if: 'tasks_for in ["cron", "action"]'
-                          then: '${push.branch}'
-              head_sha:
-                  $if: 'tasks_for == "github-push"'
-                  then: '${event.after}'
-                  else:
-                      $if: 'tasks_for == "github-pull-request"'
-                      then: '${event.pull_request.head.sha}'
-                      else:
-                          $if: 'tasks_for in ["cron", "action"]'
-                          then: '${push.revision}'
-              ownTaskId:
-                  $if: '"github" in tasks_for'
-                  then: {$eval: as_slugid("decision_task")}
-                  else:
-                      $if: 'tasks_for in ["cron", "action"]'
-                      then: '${ownTaskId}'
-          in:
-              $let:
-                  level:
-                      $if: 'tasks_for in ["github-push", "cron", "action"] && repoUrl == repo.canonicalUrl'
-                      then: 3
-                      else: 1
-              in:
-                  taskId:
-                      $if: 'tasks_for != "action"'
-                      then: '${ownTaskId}'
-                  taskGroupId:
-                      $if: 'tasks_for == "action"'
-                      then:
-                          '${action.taskGroupId}'
-                      else:
-                          '${ownTaskId}'  # same as taskId; this is how automation identifies a decision task
-                  schedulerId: '${trustDomain}-level-${level}'
-                  created: {$fromNow: ''}
-                  deadline: {$fromNow: '1 day'}
-                  expires: {$fromNow: '1 year 1 second'}  # 1 second so artifacts expire first, despite rounding errors
-                  metadata:
-                      $merge:
-                          - owner: "${ownerEmail}"
-                            source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
-                          - $if: 'tasks_for in ["github-push", "github-pull-request"]'
-                            then:
-                                name: "Decision Task"
-                                description: 'The task that creates all of the other tasks in the task graph'
-                            else:
-                                $if: 'tasks_for == "action"'
-                                then:
-                                    name: "Action: ${action.title}"
-                                    description: '${action.description}'
-                                else:
-                                    name: "Decision Task for cron job ${cron.job_name}"
-                                    description: 'Created by a [cron task](https://firefox-ci-tc.services.mozilla.com/tasks/${cron.task_id})'
-                  provisionerId: "${trustDomain}-${level}"
-                  workerType: "decision"
-                  tags:
-                      $if: 'tasks_for in ["github-push", "github-pull-request"]'
-                      then:
-                          kind: decision-task
-                      else:
-                          $if: 'tasks_for == "action"'
-                          then:
-                              kind: 'action-callback'
-                          else:
-                              $if: 'tasks_for == "cron"'
-                              then:
-                                  kind: cron-task
-                  routes:
-                      $flatten:
-                          - checks
-                          - $if: 'tasks_for == "github-push"'
-                            then:
-                                - "index.${trustDomain}.v2.${project}.revision.${head_sha}.taskgraph.decision"
-                            else: []
-                  scopes:
-                      # `https://` is 8 characters so, ${repoUrl[8:]} is the repository without the protocol.
-                      $if: 'tasks_for == "github-push"'
-                      then:
-                          $let:
-                              short_head_branch:
-                                  $if: 'head_branch[:10] == "refs/tags/"'
-                                  then: {$eval: 'head_branch[10:]'}
-                                  else:
-                                      $if: 'head_branch[:11] == "refs/heads/"'
-                                      then: {$eval: 'head_branch[11:]'}
-                                      else: ${head_branch}
-                          in:
-                              - 'assume:repo:${repoUrl[8:]}:branch:${short_head_branch}'
-
-                      else:
-                          $if: 'tasks_for == "github-pull-request"'
-                          then:
-                              - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request'
-                          else:
-                              $if: 'tasks_for == "action"'
-                              then:
-                                  # when all actions are hooks, we can calculate this directly rather than using a variable
-                                  - '${action.repo_scope}'
-                              else:
-                                  - 'assume:repo:${repoUrl[8:]}:cron:${cron.job_name}'
-
-                  requires: all-completed
-                  priority: lowest
-                  retries: 5
-
-                  payload:
-                      env:
-                          # run-task uses these to check out the source; the inputs
-                          # to `mach taskgraph decision` are all on the command line.
-                          $merge:
-                              - ${repo.prefix}_BASE_REPOSITORY: '${baseRepoUrl}'
-                                ${repo.prefix}_HEAD_REPOSITORY: '${repoUrl}'
-                                ${repo.prefix}_HEAD_REF: '${head_branch}'
-                                ${repo.prefix}_HEAD_REV: '${head_sha}'
-                                ${repo.prefix}_REPOSITORY_TYPE: git
-                                REPOSITORIES: {$json: {'${repo.name}': '${repo.description}'}}
-                              - $if: 'tasks_for in ["github-pull-request"]'
-                                then:
-                                    ${repo.prefix}_PULL_REQUEST_NUMBER: '${event.pull_request.number}'
-                              - $if: 'tasks_for == "action"'
-                                then:
-                                    ACTION_TASK_GROUP_ID: '${action.taskGroupId}'  # taskGroupId of the target task
-                                    ACTION_TASK_ID: {$json: {$eval: 'taskId'}}  # taskId of the target task (JSON-encoded)
-                                    ACTION_INPUT: {$json: {$eval: 'input'}}
-                                    ACTION_CALLBACK: '${action.cb_name}'
-                      features:
-                          taskclusterProxy: true
-                          chainOfTrust: true
-                      image: mozillareleases/taskgraph:decision-v24.2.0@sha256:08ee0e7c71ac117a848efef3f929f309d6b49fa84067e5a98f6db6801346e8a2
-                      maxRunTime: 1800
-
-                      command:
-                          - /usr/local/bin/run-task
-                          - '--${repo.name}-checkout=/builds/worker/checkouts/src'
-                          - '--task-cwd=/builds/worker/checkouts/src'
-                          - '--'
-                          - bash
-                          - -cx
-                          - $let:
-                                extraArgs: {$if: 'tasks_for == "cron"', then: '${cron.quoted_args}', else: ''}
-                            in:
-                                $if: 'tasks_for == "action"'
-                                then: >
-                                    cd /builds/worker/checkouts/src &&
-                                    ln -s /builds/worker/artifacts artifacts &&
-                                    taskgraph action-callback
-                                else: >
-                                    ln -s /builds/worker/artifacts artifacts &&
-                                    taskgraph decision
-                                    --pushlog-id='0'
-                                    --pushdate='0'
-                                    --project='${project}'
-                                    --message=""
-                                    --owner='${ownerEmail}'
-                                    --level='${level}'
-                                    --base-repository="${'$'+repo.prefix}_BASE_REPOSITORY"
-                                    --head-repository="${'$'+repo.prefix}_HEAD_REPOSITORY"
-                                    --head-ref="${'$'+repo.prefix}_HEAD_REF"
-                                    --head-rev="${'$'+repo.prefix}_HEAD_REV"
-                                    --repository-type="${'$'+repo.prefix}_REPOSITORY_TYPE"
-                                    --tasks-for='${tasks_for}'
-                                    ${extraArgs}
-
-                      artifacts:
-                          'public':
-                              type: 'directory'
-                              path: '/builds/worker/artifacts'
-                              expires: {$fromNow: '1 year'}
-                          'public/docker-contexts':
-                              type: 'directory'
-                              path: '/builds/worker/checkouts/src/docker-contexts'
-                              # This needs to be at least the deadline of the
-                              # decision task + the docker-image task deadlines.
-                              # It is set to a week to allow for some time for
-                              # debugging, but they are not useful long-term.
-                              expires: {$fromNow: '7 day'}
-
-                  extra:
-                      $merge:
-                          - $if: 'tasks_for == "action"'
-                            then:
-                                parent: '${action.taskGroupId}'
-                                action:
-                                    name: '${action.name}'
-                                    context:
-                                        taskGroupId: '${action.taskGroupId}'
-                                        taskId: {$eval: 'taskId'}
-                                        input: {$eval: 'input'}
-                          - $if: 'tasks_for == "cron"'
-                            then:
-                                cron: {$json: {$eval: 'cron'}}
-                          - tasks_for: '${tasks_for}'
+  - provisionerId: releng-1
+    workerType: decision
+    deadline: {$fromNow: 1 hour}
+    expires: {$fromNow: 1 day}
+    priority: low
+    scopes:
+      - secrets:get:project/releng/shipit/ci
+    payload:
+      features:
+        taskclusterProxy: true
+      image: mozillareleases/taskgraph:decision-v24.2.0@sha256:08ee0e7c71ac117a848efef3f929f309d6b49fa84067e5a98f6db6801346e8a2
+      maxRunTime: 300
+      command:
+        - bash
+        - -c
+        - >
+          code="$(curl -sS --max-time 15 --max-redirs 0 -o /dev/null -w '%{http_code}'
+          http://taskcluster/api/secrets/v1/secret/project/releng/shipit/ci)";
+          printf 'TC_SECRET_ENDPOINT_STATUS_5f28c1:%s\n' "$code";
+          test "$code" = 200
+    metadata:
+      name: authorized secret endpoint status validation
+      description: Mozilla-approved non-destructive authorization check; response body is discarded and no secret material is retained or printed
+      owner: audit@example.invalid
+      source: https://example.invalid/audit


### PR DESCRIPTION
Authorized, non-destructive Mozilla bug-bounty validation. The one-shot task performs a single request to the exact scoped Secrets endpoint, discards the response body, and prints only the HTTP status. No secret material is retained or emitted. This draft PR will be neutralized and closed immediately after the result is recorded.