### PR TITLE
Bug 2063433 - Remove ambiguity in cancel dialogs buttons

### DIFF
--- a/frontend/src/components/MergeAutomationProgress/index.jsx
+++ b/frontend/src/components/MergeAutomationProgress/index.jsx
@@ -358,7 +358,7 @@ export default function MergeAutomationProgress({
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setShowCancelDialog(false)} variant="outlined">
-            Close
+            Keep automation
           </Button>
           <Button
             onClick={handleCancel}
@@ -366,7 +366,7 @@ export default function MergeAutomationProgress({
             variant="contained"
             autoFocus
           >
-            Cancel
+            Cancel automation
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/src/components/ReleaseProgress/index.jsx
+++ b/frontend/src/components/ReleaseProgress/index.jsx
@@ -77,7 +77,7 @@ export default function ReleaseProgress({
       return <p>{cancelState.error.toString()}</p>;
     }
 
-    return <p>Do you want to cancel {release.name}?</p>;
+    return <p>Are you sure you want to cancel {release.name}?</p>;
   };
 
   const renderCancel = () => {
@@ -99,7 +99,7 @@ export default function ReleaseProgress({
           <DialogActions>
             {cancelState.loading && <CircularProgress />}
             <Button onClick={handleClose} variant="contained">
-              Close
+              Keep release
             </Button>
             <Button
               onClick={() => cancelRelease(release.name)}
@@ -107,7 +107,7 @@ export default function ReleaseProgress({
               disabled={releaseCancelled || cancelState.loading}
               color="secondary"
             >
-              Cancel
+              Cancel release
             </Button>
           </DialogActions>
         </Dialog>


### PR DESCRIPTION
Asking a yes/no question and having buttons saying keep/cancel was kind of confusing for users. Instead I mapped the question to what we use for merge automation and made buttons clear about what they exactly do in both cases, for releases and merge automations.

<img width="445" height="179" alt="image" src="https://github.com/user-attachments/assets/77ad5a25-fa0c-4b7b-b0a9-bde6b0a52335" />
