### PR TITLE
Re-enable refresh tokens in the UI

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -30,6 +30,7 @@ const App = () => {
             scope: config.AUTH0.scope,
           }}
           leeway={30}
+          useRefreshTokens
           cacheLocation="localstorage"
           sessionCheckExpiryDays={7}
         >


### PR DESCRIPTION
I had disabled them in #1713 because the auth0 tenant config didn't have those enabled and it ended up confusing the UI. They're now enabled (on staging, prod will follow once I confirm staging works, see https://mozilla-hub.atlassian.net/browse/IAM-2082)

This is basically the same as
https://github.com/mozilla-releng/balrog/pull/3812