### PR TITLE
Bug 2067744 - Revert "Re-enable refresh tokens in the UI (#2038)"

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -30,7 +30,6 @@ const App = () => {
             scope: config.AUTH0.scope,
           }}
           leeway={30}
-          useRefreshTokens
           cacheLocation="localstorage"
           sessionCheckExpiryDays={7}
         >


### PR DESCRIPTION
This reverts commit 9f44663465215564d5092e945452acb3bcf32311.

Refreshed tokens don't have LDAP group informations due to a bug in the auth0 configuration. This bug is tracked and should be fixed at some point but while it's present, refresh tokens make things a lot more painful because they work but using any refreshed token just leads to 500s because the tokens are incomplete, requiring an explicit logout/login.

Disable refresh tokens again until that bug is fixed.